### PR TITLE
update compute defaults to ignore research sources

### DIFF
--- a/scope3_methodology/compute_defaults.py
+++ b/scope3_methodology/compute_defaults.py
@@ -62,16 +62,16 @@ def main():
 
     # get a list of all facts from our sources
     facts: dict[str, list[float]] = {}
-    files = glob("sources/**/*.yaml", recursive=True)
+    files = glob("sources/**^research/*.yaml", recursive=True)
     for file in files:
         stream = open(file, "r")
         documents = list(yaml.load_all(stream, Loader=SafeLoader))
         for document in documents:
             if "company" not in document:
-                print("No company found in " + document)
+                print("No company found in " + file + " Contents: " + str(document))
                 continue
             if "sources" not in document["company"]:
-                print("No sources found in " + document)
+                print("No sources found in  " + file + " Contents: " + str(document))
                 continue
             for source in document["company"]["sources"]:
                 for fact in source["facts"]:


### PR DESCRIPTION
Just tried to compute defaults and saw it was broken when last PR was merged. 

For now going to ignore the newly added `sources/research` files which will error 


First Error => update the print statement 
```
Traceback (most recent call last):
  File "/Users/emmaetherington/scope3/methodology/./scope3_methodology/compute_defaults.py", line 131, in <module>
    main()
  File "/Users/emmaetherington/scope3/methodology/./scope3_methodology/compute_defaults.py", line 71, in main
    print("No company found in " + document)
``` 

Then when you run it again
```
No company found in sources/research/ADEME-ARCEP/data.yaml Contents: {'sources': [{'year': 2022, 'name': 'Evaluation environnementale des équipements et infrastructures numériques en France (2ème volet), ADEME-ARCEP', 'url': 'https://www.arcep.fr/uploads/tx_gspublication/etude-numerique-environnement-ademe-arcep-volet02_janv2022.pdf', 'comment': 'has embodied emissions data for various kinds of equipment'}, {'year': 2020, 'name': 'European Commission, ICT Impact study, Final report', 'url': 'https://www.arcep.fr/uploads/tx_gspublication/etude-numerique-environnement-ademe-arcep-volet02_janv2022.pdf', 'comment': 'probably more good data points to pull from this study', 'facts': [{'fixed network data transfer electricity use kwh per gb': 0.03, 'reference': 'page 73', 'comment': 'ADEME study says this is "excluding box"'}, {'mobile network data transfer electricity use kwh per gb': 0.14, 'reference': 'page 73'}]}]}
```