### PR TITLE
fix compute defaults with overlapping template names

### DIFF
--- a/scope3_methodology/cli/compute_defaults.py
+++ b/scope3_methodology/cli/compute_defaults.py
@@ -87,7 +87,8 @@ def compute_defaults(
     template_defaults = {}
     template_defaults_sources = {}
 
-    for name, template in templates.items():
+    for _, template in templates.items():
+        name = template["name"]
         if str(template["type"]) != model:
             continue
 
@@ -161,7 +162,9 @@ def main():
             if "type" not in document["template"]:
                 raise Exception(f"'type' field not found in {file}")
             name = document["template"]["name"]
-            templates[name] = document["template"]
+            template_type = document["template"]["type"]
+            template_key = f"{name}-{template_type}"
+            templates[template_key] = document["template"]
 
     for model, keys in model_keys.items():
         compute_defaults(


### PR DESCRIPTION
So this happened because we had 
```
---
template:
  name: generic
  template: generic 
  type: organization
```
and we added 
```
---
template:
  name: generic
  template: generic
  type: property
```

So the name was the same, so when building the compute defaults we override the templates key. So we stopped computing defaults for `generic` organization. 

Update: the key is now on the combination of `name-type` which should always be a unique pairing. We should never have 2 templates of the same name and same type. 

This is the quick fix further updates needed:
- Add in tests for the computed files so that we a user is aware when they change computed files and can verify the change 
- Validation check on PR to prevent multiple templates being merged with the same name-type combination 