### PR TITLE
Add device emissions per second

### DIFF
--- a/scope3_methodology/end_user_device/model.py
+++ b/scope3_methodology/end_user_device/model.py
@@ -16,6 +16,8 @@ class ModeledEndUserDevice:
     template: str
     power_kwh_per_imp: Decimal
     production_gco2e_per_imp: Decimal
+    power_kwh_per_second: Decimal
+    production_gco2e_per_second: Decimal
 
 
 @dataclass
@@ -43,6 +45,12 @@ class EndUserDevice(CustomBaseModel):
         log_result("power_emissions_kwh_per_imp", kwh_per_imp, 2)
         return kwh_per_imp
 
+    def compute_power_emissions_kwh_per_second(self):
+        """Device kilowatts"""
+        kwh_per_second = (self.draw_watts) / Decimal("1000") / Decimal("3600")
+        log_result("power_emissions_kwh_per_second", kwh_per_second, 2)
+        return kwh_per_second
+
     def model_end_user_device(
         self,
         device: str,
@@ -58,6 +66,7 @@ class EndUserDevice(CustomBaseModel):
         power_kwh_per_imp = self.compute_power_emissions_kwh_per_imp(
             quality_impressions_per_duration_s
         )
+        power_kwh_per_second = self.compute_power_emissions_kwh_per_second()
         production_gco2e_per_imp = self.compute_production_emissions_gco2e_per_imp(
             quality_impressions_per_duration_s
         )
@@ -68,4 +77,6 @@ class EndUserDevice(CustomBaseModel):
             template,
             power_kwh_per_imp,
             production_gco2e_per_imp,
+            power_kwh_per_second,
+            self.production_emissions_gco2e_per_duration_s,
         )

--- a/scope3_methodology/test/test_end_user_device_model.py
+++ b/scope3_methodology/test/test_end_user_device_model.py
@@ -34,12 +34,18 @@ class TestEndUserDeviceModel(unittest.TestCase):
         self.assertEqual(production_gco2e_per_imp, Decimal("0.07000000"))
 
     def test_compute_power_emissions_kwh_per_imp(self):
-        """Test compute power emissions"""
+        """Test compute power emissions per imp"""
         device = EndUserDevice.load_default_yaml(TEST_DEVICE, TEST_DEFAULTS_FILE)
         power_kwh_per_imp = device.compute_power_emissions_kwh_per_imp(
             TEST_QUALITY_IMPRESSIONS_PER_SEC
         )
         self.assertEqual(power_kwh_per_imp, Decimal("0.0001477777777777777777777777778"))
+
+    def test_compute_power_emissions_kwh_per_second(self):
+        """Test compute power emissions per second"""
+        device = EndUserDevice.load_default_yaml(TEST_DEVICE, TEST_DEFAULTS_FILE)
+        power_kwh_per_second = device.compute_power_emissions_kwh_per_second()
+        self.assertEqual(power_kwh_per_second, Decimal("0.00001477777777777777777777777778"))
 
     def test_model_end_user_device_personal_computer(self):
         """Test model end user devices"""
@@ -55,6 +61,8 @@ class TestEndUserDeviceModel(unittest.TestCase):
                 TEST_TEMPLATE,
                 Decimal("0.0001477777777777777777777777778"),
                 Decimal("0.07000000"),
+                Decimal("0.00001477777777777777777777777778"),
+                device.production_emissions_gco2e_per_duration_s,
             ),
         )
 
@@ -73,6 +81,8 @@ class TestEndUserDeviceModel(unittest.TestCase):
                 TEST_TEMPLATE,
                 Decimal("0.000002138888888888888888888888889"),
                 Decimal("0.052000000"),
+                Decimal("0.0000002138888888888888888888888889"),
+                device.production_emissions_gco2e_per_duration_s,
             ),
         )
 


### PR DESCRIPTION
Exposing these new model fields for creative usage.

For production creative:  we have production grams per second which we can then do `production_g_per_second` * `creative_s` = `gco2e` emissions  

For device emissions of playing the ads we use `power_emissions_kwh_per_second` which we then do `power_emissions_kwh_per_second` * `creative_duration_s` * `gco2e_per_kwh` = `gco2e` emissions 