### PR TITLE
Update Corporate Emissions Model

### DIFF
--- a/data/companies/rea_group/corporate.yaml
+++ b/data/companies/rea_group/corporate.yaml
@@ -15,6 +15,9 @@ facts:
   - travel_emissions_mt_co2e_per_employee_per_month: 0.0490
     calculation: true
     reference: page 57
+  - revenue_allocation_to_digital_ads_pct: 8.7
+    source_id: 2
+    comment: 96.9/1115.6
 raw_data:
   - office emissions mt: 1770.79
     source_id: 1
@@ -37,3 +40,7 @@ reference_files:
     id: 1
     url: >-
       https://cdn.rea-group.com/wp-content/uploads/2022/09/16091556/Sustainability-Report-2022.pdf
+  - id: 2
+    year: 2022
+    month: 10
+    url: https://rea3.irmau.com/site/pdf/5145f68f-b0b6-4192-8039-382acf1e0a37/REA-Group-Investor-and-Analyst-Presentation.pdf

--- a/data/companies/rea_group/property_data.yaml
+++ b/data/companies/rea_group/property_data.yaml
@@ -11,8 +11,9 @@ properties:
         source_id: 1
       - average_visit_duration_s: 392
         source_id: 1
-      - corporate_emissions_g_co2e_per_impression: 0.0791
+      - corporate_emissions_g_co2e_per_impression: 0.079071871
         calculation: true
+        comment: Output of model March 21, 2023
   - channel: display-web
     template: generic
     identifier: realcommercial.com.au
@@ -55,17 +56,16 @@ properties:
         source_id: 1
 
 raw_facts:
-  - corporate_emissions_g_co2e_per_month: 2550595000
-    source_id: 3
-    comment: Output of model Nov 14, 2022
-  - revenue_allocation_to_display_pct: 8.7
-    source_id: 3
-    comment: 96.9/1115.6
+  - total_corporate_emissions_g_co2e_per_month: 2550595000
+    comment: Output of model Mar 21, 2023
+  - digital_ads_allocation_corporate_emissions_g_co2e_per_month: 221901765.000000000
+    comment: Output of model Mar 21, 2023
   - quality_impressions_per_month: 2806330000
     calculation: true
     comment: 0.1 qimps/sec x sessions/mo x time/session x % display
-  - corporate_emissions_g_co2e_per_impression: 0.0791
+  - corporate_emissions_g_co2e_per_impression: 0.079071871
     calculation: true
+    comment: Output of model Mar 21, 2023
 sources:
   - id: 1
     year: 2022

--- a/data/companies/theguardian/corporate.yaml
+++ b/data/companies/theguardian/corporate.yaml
@@ -11,6 +11,9 @@ facts:
     calculation: true
   - travel_emissions_mt_co2e_per_employee_per_month: 0.137
     calculation: true
+  - revenue_allocation_to_digital_ads_pct: 14.9
+    source_id: 3
+    comment: advertising is £73.7/£255.8; assuming digital is 51.6% as with reader rev
 raw_data:
   - advertising_revenue_gbp_per_year: 73.7
     source_id: 1
@@ -39,3 +42,7 @@ reference_files:
     url: >-
       https://uploads.guim.co.uk/2021/08/25/Positive_Impact_Sustainability_Report_1920.pdf
     file: Positive_Impact_Sustainability_Report_1920.pdf
+  - id: 3
+    year: 2022
+    month: 4
+    url: https://uploads.guim.co.uk/2022/07/20/GMG_Financial_Statements_2022.pdf

--- a/data/companies/theguardian/property_data.yaml
+++ b/data/companies/theguardian/property_data.yaml
@@ -9,7 +9,7 @@ properties:
     facts:
       - visits_per_month: 404400000
         source_id: 1
-      - pages_per_visit:  3.43
+      - pages_per_visit: 3.43
         source_id: 1
       - average_visit_duration_s: 291
         source_id: 1
@@ -17,17 +17,16 @@ properties:
         source_id: 2
       - load_time_s: 1.89
         source_id: 2
-      - corporate_emissions_g_co2e_per_impression: 0.019
+      - corporate_emissions_g_co2e_per_impression: 0.018965959
         calculation: true
-      - revenue_allocation_to_display_pct: 14.9
-        source_id: 4
-        comment: advertising is £73.7/£255.8; assuming digital is 51.6% as with reader rev
+        comment: Output of model March 21, 2023
     raw_facts:
       - requests_per_page: 219
         source_id: 2
-      - corporate_emissions_g_co2e_per_month: 1497934000
-        source_id: 3
-        comment: Output of model Nov 14, 2022
+      - total_corporate_emissions_g_co2e_per_month: 1497934000.000000000
+        comment: Output of model Mar 21, 2023
+      - digital_ads_allocation_corporate_emissions_g_co2e_per_month: 223192166.000000000
+        comment: Output of model Mar 21, 2023
       - quality_impressions_per_month: 11,768,040,000
         calculation: true
         comment: 0.1 qimps/sec x sessions/mo x time/session x % display
@@ -44,7 +43,7 @@ properties:
         year: 2022
         month: 11
         url: https://github.com/scope3data/methodology
-        comment: ./scope3_methodology/cli/model_corporate_emissions.py publisher data/companies/theguardian/corporate.yaml 
+        comment: ./scope3_methodology/cli/model_corporate_emissions.py publisher data/companies/theguardian/corporate.yaml
       - id: 4
         year: 2022
         month: 4

--- a/defaults/organization-defaults.yaml
+++ b/defaults/organization-defaults.yaml
@@ -5,18 +5,21 @@ defaults:
     datacenter_emissions_mt_co2e_per_employee_per_month: 0.362000000
     office_emissions_mt_co2e_per_employee_per_month: 0.017600000
     overhead_emissions_mt_co2e_per_employee_per_month: 0.314000000
+    revenue_allocation_to_digital_ads_pct: 11.800000000
     travel_emissions_mt_co2e_per_employee_per_month: 0.011000000
   generic:
     commuting_emissions_mt_co2e_per_employee_per_month: 0.043000000
     datacenter_emissions_mt_co2e_per_employee_per_month: 0.362000000
     office_emissions_mt_co2e_per_employee_per_month: 0.112920000
     overhead_emissions_mt_co2e_per_employee_per_month: 0.314000000
+    revenue_allocation_to_digital_ads_pct: 100
     travel_emissions_mt_co2e_per_employee_per_month: 0.044600000
   publisher:
     commuting_emissions_mt_co2e_per_employee_per_month: 0.043000000
     datacenter_emissions_mt_co2e_per_employee_per_month: 0.362000000
     office_emissions_mt_co2e_per_employee_per_month: 0.136750000
     overhead_emissions_mt_co2e_per_employee_per_month: 0.314000000
+    revenue_allocation_to_digital_ads_pct: 11.800000000
     travel_emissions_mt_co2e_per_employee_per_month: 0.053000000
 sources:
   atp:
@@ -66,6 +69,21 @@ sources:
         template: publisher
         url: n/a
         value: 0.314000000
+    revenue_allocation_to_digital_ads_pct:
+      - channel: null
+        company: theguardian/corporate.yaml
+        is_calculation: false
+        key: revenue_allocation_to_digital_ads_pct
+        template: publisher
+        url: n/a
+        value: 14.900000000
+      - channel: null
+        company: rea_group/corporate.yaml
+        is_calculation: false
+        key: revenue_allocation_to_digital_ads_pct
+        template: publisher
+        url: n/a
+        value: 8.700000000
     travel_emissions_mt_co2e_per_employee_per_month:
       - channel: null
         company: criteo/corporate.yaml
@@ -149,6 +167,8 @@ sources:
         template: publisher
         url: n/a
         value: 0.314000000
+    revenue_allocation_to_digital_ads_pct:
+      - template default
     travel_emissions_mt_co2e_per_employee_per_month:
       - channel: null
         company: theguardian/corporate.yaml
@@ -253,6 +273,21 @@ sources:
         template: publisher
         url: n/a
         value: 0.314000000
+    revenue_allocation_to_digital_ads_pct:
+      - channel: null
+        company: theguardian/corporate.yaml
+        is_calculation: false
+        key: revenue_allocation_to_digital_ads_pct
+        template: publisher
+        url: n/a
+        value: 14.900000000
+      - channel: null
+        company: rea_group/corporate.yaml
+        is_calculation: false
+        key: revenue_allocation_to_digital_ads_pct
+        template: publisher
+        url: n/a
+        value: 8.700000000
     travel_emissions_mt_co2e_per_employee_per_month:
       - channel: null
         company: theguardian/corporate.yaml

--- a/defaults/property-defaults.yaml
+++ b/defaults/property-defaults.yaml
@@ -5,56 +5,41 @@ defaults:
       computer_active_electricity_use_watts: 120
       computer_idle_electricity_use_watts: 40
       core_internet_data_transfer_electricity_use_kwh_per_gb: 0.000066700
-      corporate_emissions_g_co2e_per_impression: 0.049050000
+      corporate_emissions_g_co2e_per_impression: 0.049018915
       end_user_data_transfer_electricity_use_kwh_per_gb: 0.100000000
       quality_impressions_per_duration_s: 0.100000000
-      revenue_allocation_to_ads_pct: 100
-      revenue_allocation_to_digital_pct: 100
-      revenue_allocation_to_display_pct: 100
   display-app:
     generic:
       computer_active_electricity_use_watts: 120
       computer_idle_electricity_use_watts: 40
       core_internet_data_transfer_electricity_use_kwh_per_gb: 0.000066700
-      corporate_emissions_g_co2e_per_impression: 0.049050000
+      corporate_emissions_g_co2e_per_impression: 0.049018915
       end_user_data_transfer_electricity_use_kwh_per_gb: 0.100000000
       quality_impressions_per_duration_s: 0.100000000
-      revenue_allocation_to_ads_pct: 100
-      revenue_allocation_to_digital_pct: 100
-      revenue_allocation_to_display_pct: 100
   display-web:
     generic:
       computer_active_electricity_use_watts: 120
       computer_idle_electricity_use_watts: 40
       core_internet_data_transfer_electricity_use_kwh_per_gb: 0.000066700
-      corporate_emissions_g_co2e_per_impression: 0.049050000
+      corporate_emissions_g_co2e_per_impression: 0.049018915
       end_user_data_transfer_electricity_use_kwh_per_gb: 0.100000000
       quality_impressions_per_duration_s: 0.100000000
-      revenue_allocation_to_ads_pct: 100
-      revenue_allocation_to_digital_pct: 100
-      revenue_allocation_to_display_pct: 100
   streaming:
     generic:
       computer_active_electricity_use_watts: 120
       computer_idle_electricity_use_watts: 40
       core_internet_data_transfer_electricity_use_kwh_per_gb: 0.000066700
-      corporate_emissions_g_co2e_per_impression: 0.049050000
+      corporate_emissions_g_co2e_per_impression: 0.049018915
       end_user_data_transfer_electricity_use_kwh_per_gb: 0.100000000
       quality_impressions_per_duration_s: 0.003200000
-      revenue_allocation_to_ads_pct: 100
-      revenue_allocation_to_digital_pct: 100
-      revenue_allocation_to_display_pct: 14.900000000
   streaming-video:
     generic:
       computer_active_electricity_use_watts: 120
       computer_idle_electricity_use_watts: 40
       core_internet_data_transfer_electricity_use_kwh_per_gb: 0.000066700
-      corporate_emissions_g_co2e_per_impression: 0.049050000
+      corporate_emissions_g_co2e_per_impression: 0.049018915
       end_user_data_transfer_electricity_use_kwh_per_gb: 0.100000000
       quality_impressions_per_duration_s: 0.003200000
-      revenue_allocation_to_ads_pct: 100
-      revenue_allocation_to_digital_pct: 100
-      revenue_allocation_to_display_pct: 14.900000000
 sources:
   display:
     generic:
@@ -77,14 +62,14 @@ sources:
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.019000000
+          value: 0.018965959
         - channel: display-web
           company: rea_group/property_data.yaml
           is_calculation: true
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.079100000
+          value: 0.079071871
       end_user_data_transfer_electricity_use_kwh_per_gb:
         - channel: null
           company: VTT/data.yaml
@@ -94,12 +79,6 @@ sources:
           url: https://www.mdpi.com/2071-1050/10/7/2494
           value: 0.100000000
       quality_impressions_per_duration_s:
-        - template default
-      revenue_allocation_to_ads_pct:
-        - template default
-      revenue_allocation_to_digital_pct:
-        - template default
-      revenue_allocation_to_display_pct:
         - template default
   display-app:
     generic:
@@ -122,14 +101,14 @@ sources:
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.019000000
+          value: 0.018965959
         - channel: display-web
           company: rea_group/property_data.yaml
           is_calculation: true
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.079100000
+          value: 0.079071871
       end_user_data_transfer_electricity_use_kwh_per_gb:
         - channel: null
           company: VTT/data.yaml
@@ -139,12 +118,6 @@ sources:
           url: https://www.mdpi.com/2071-1050/10/7/2494
           value: 0.100000000
       quality_impressions_per_duration_s:
-        - template default
-      revenue_allocation_to_ads_pct:
-        - template default
-      revenue_allocation_to_digital_pct:
-        - template default
-      revenue_allocation_to_display_pct:
         - template default
   display-web:
     generic:
@@ -167,14 +140,14 @@ sources:
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.019000000
+          value: 0.018965959
         - channel: display-web
           company: rea_group/property_data.yaml
           is_calculation: true
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.079100000
+          value: 0.079071871
       end_user_data_transfer_electricity_use_kwh_per_gb:
         - channel: null
           company: VTT/data.yaml
@@ -184,12 +157,6 @@ sources:
           url: https://www.mdpi.com/2071-1050/10/7/2494
           value: 0.100000000
       quality_impressions_per_duration_s:
-        - template default
-      revenue_allocation_to_ads_pct:
-        - template default
-      revenue_allocation_to_digital_pct:
-        - template default
-      revenue_allocation_to_display_pct:
         - template default
   streaming:
     generic:
@@ -212,14 +179,14 @@ sources:
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.019000000
+          value: 0.018965959
         - channel: display-web
           company: rea_group/property_data.yaml
           is_calculation: true
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.079100000
+          value: 0.079071871
       end_user_data_transfer_electricity_use_kwh_per_gb:
         - channel: null
           company: VTT/data.yaml
@@ -230,18 +197,6 @@ sources:
           value: 0.100000000
       quality_impressions_per_duration_s:
         - template default
-      revenue_allocation_to_ads_pct:
-        - template default
-      revenue_allocation_to_digital_pct:
-        - template default
-      revenue_allocation_to_display_pct:
-        - channel: display-web
-          company: theguardian/property_data.yaml
-          is_calculation: false
-          key: revenue_allocation_to_display_pct
-          template: generic
-          url: n/a
-          value: 14.900000000
   streaming-video:
     generic:
       computer_active_electricity_use_watts:
@@ -263,14 +218,14 @@ sources:
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.019000000
+          value: 0.018965959
         - channel: display-web
           company: rea_group/property_data.yaml
           is_calculation: true
           key: corporate_emissions_g_co2e_per_impression
           template: generic
           url: n/a
-          value: 0.079100000
+          value: 0.079071871
       end_user_data_transfer_electricity_use_kwh_per_gb:
         - channel: null
           company: VTT/data.yaml
@@ -281,15 +236,3 @@ sources:
           value: 0.100000000
       quality_impressions_per_duration_s:
         - template default
-      revenue_allocation_to_ads_pct:
-        - template default
-      revenue_allocation_to_digital_pct:
-        - template default
-      revenue_allocation_to_display_pct:
-        - channel: display-web
-          company: theguardian/property_data.yaml
-          is_calculation: false
-          key: revenue_allocation_to_display_pct
-          template: generic
-          url: n/a
-          value: 14.900000000

--- a/scope3_methodology/api/api.py
+++ b/scope3_methodology/api/api.py
@@ -149,6 +149,7 @@ def calculate_corporate_emissions(data: CorporateInput):
         commuting_emissions_mt_co2e_per_employee_per_month=data.commuting_emissions_mt_co2e_per_employee_per_month,
         overhead_emissions_mt_co2e_per_employee_per_month=data.overhead_emissions_mt_co2e_per_employee_per_month,
         corporate_emissions_mt_co2e_per_month=data.corporate_emissions_mt_co2e_per_month,
+        revenue_allocation_to_digital_ads_pct=data.revenue_allocation_to_digital_ads_pct,
         number_of_employees=data.number_of_employees,
     )
 

--- a/scope3_methodology/api/input_models.py
+++ b/scope3_methodology/api/input_models.py
@@ -70,6 +70,7 @@ class CorporateInput(BaseModel):
     commuting_emissions_mt_co2e_per_employee_per_month: Optional[Decimal]
     overhead_emissions_mt_co2e_per_employee_per_month: Optional[Decimal]
     corporate_emissions_mt_co2e_per_month: Optional[Decimal]
+    revenue_allocation_to_digital_ads_pct: Optional[Decimal]
 
 
 class ATPInput(BaseModel):

--- a/scope3_methodology/cli/model_corporate_emissions.py
+++ b/scope3_methodology/cli/model_corporate_emissions.py
@@ -45,7 +45,7 @@ def main():
         defaults = CorporateEmissions.load_default_yaml(args.type, args.defaultsFile)
         org_emissions = corp.comp_emissions_g_co2e_per_month(defaults, depth - 1)
 
-    print(yaml_dump({"corporate_emissions_g_co2e_per_month": org_emissions}))
+    print(yaml_dump(org_emissions))
 
 
 if __name__ == "__main__":

--- a/scope3_methodology/cli/model_publisher_emissions.py
+++ b/scope3_methodology/cli/model_publisher_emissions.py
@@ -69,14 +69,14 @@ def parse_args():
         const=1,
         type=Decimal,
         nargs="?",
-        help="Provide the corporate emissions for organization",
+        help="Provide the corporate emissions allocated to digital advertising for organization",
     )
     parser.add_argument(
         "--corporateEmissionsGPerImp",
         const=1,
         type=Decimal,
         nargs="?",
-        help="Provide the corporate emissions for organization per impression",
+        help="Provide the corporate emissions per impression for organization",
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="Show derivation of output")
     parser.add_argument("companyFile", nargs=1, help="The company file to parse in YAML format")

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -75,6 +75,10 @@ class TestAPI(unittest.TestCase):
             ].travel_emissions_mt_co2e_per_employee_per_month,
             Decimal("0.053"),
         )
+        self.assertEqual(
+            organization_defaults[OrganizationType.PUBLISHER].revenue_allocation_to_digital_ads_pct,
+            Decimal("11.8"),
+        )
         self.assertTrue(organization_defaults[OrganizationType.GENERIC])
         self.assertEqual(
             organization_defaults[

--- a/templates/organization/generic.yaml
+++ b/templates/organization/generic.yaml
@@ -2,3 +2,4 @@
 template:
   name: generic
   type: organization
+  revenue_allocation_to_digital_ads_pct: 100

--- a/templates/property/display-app.yaml
+++ b/templates/property/display-app.yaml
@@ -5,9 +5,6 @@ template:
   generic: true
   type: property
   quality_impressions_per_duration_s: 0.1
-  revenue_allocation_to_digital_pct: 100
-  revenue_allocation_to_ads_pct: 100
-  revenue_allocation_to_display_pct: 100
   computer_active_electricity_use_watts: 120
   computer_idle_electricity_use_watts: 40
   grid_intensity_g_co2e_per_kwh: 539.0

--- a/templates/property/display-generic.yaml
+++ b/templates/property/display-generic.yaml
@@ -6,9 +6,6 @@ template:
   generic: true
   type: property
   quality_impressions_per_duration_s: 0.1
-  revenue_allocation_to_digital_pct: 100
-  revenue_allocation_to_ads_pct: 100
-  revenue_allocation_to_display_pct: 100
   computer_active_electricity_use_watts: 120
   computer_idle_electricity_use_watts: 40
   grid_intensity_g_co2e_per_kwh: 539.0

--- a/templates/property/display-web.yaml
+++ b/templates/property/display-web.yaml
@@ -5,9 +5,6 @@ template:
   generic: true
   type: property
   quality_impressions_per_duration_s: 0.1
-  revenue_allocation_to_digital_pct: 100
-  revenue_allocation_to_ads_pct: 100
-  revenue_allocation_to_display_pct: 100
   computer_active_electricity_use_watts: 120
   computer_idle_electricity_use_watts: 40
   grid_intensity_g_co2e_per_kwh: 539.0

--- a/templates/property/streaming-generic.yaml
+++ b/templates/property/streaming-generic.yaml
@@ -9,8 +9,6 @@ template:
     - see https://www.hollywoodreporter.com/business/digital/netflix-disney-data-privacy-ads-1235234652/
     - 11.54 ads/hour is the average for streaming
   quality_impressions_per_duration_s: 0.0032
-  revenue_allocation_to_digital_pct: 100
-  revenue_allocation_to_ads_pct: 100
   computer_active_electricity_use_watts: 120
   computer_idle_electricity_use_watts: 40
   grid_intensity_g_co2e_per_kwh: 539.0

--- a/templates/property/streaming-video.yaml
+++ b/templates/property/streaming-video.yaml
@@ -8,8 +8,6 @@ template:
     - see https://www.hollywoodreporter.com/business/digital/netflix-disney-data-privacy-ads-1235234652/
     - 11.54 ads/hour is the average for streaming
   quality_impressions_per_duration_s: 0.0032
-  revenue_allocation_to_digital_pct: 100
-  revenue_allocation_to_ads_pct: 100
   computer_active_electricity_use_watts: 120
   computer_idle_electricity_use_watts: 40
   grid_intensity_g_co2e_per_kwh: 539.0


### PR DESCRIPTION
Consolidate and move revenue allocation of corporate emissions due to digital emissions to be at the organization level 


```
➜ ./scope3_methodology/cli/model_corporate_emissions.py publisher data/companies/theguardian/corporate.yaml
digital_ads_allocation_corporate_emissions_g_co2e_per_month: 223192166.000000000
revenue_allocation_to_digital_ads_pct: 14.900000000
total_corporate_emissions_g_co2e_per_month: 1497934000.000000000

➜ ./scope3_methodology/cli/model_publisher_emissions.py --corporateEmissionsG 223192166  data/companies/theguardian/property_data.yaml
properties:
- client_device_emissions_g_co2e_per_imp: 0.067987302
  corporate_emissions_g_co2e_per_impression: 0.018965959
  data_transfer_electricity_kwh: 0.000010074
  identifier: theguardian.com
  impressions: 11768040000.000000000
  page_load_electricity_kwh: 0.000116062
```