### PR TITLE
Fixed various broken links to other documentation pages

### DIFF
--- a/docs/cookie_sync_model.mdx
+++ b/docs/cookie_sync_model.mdx
@@ -9,7 +9,7 @@
 
 Using the above input data, we can calculate a "server-side" emissions cost per cookie sync of 0.000365 gCO2e.
 
-In addition, we model the average data transfer per cookie sync, approximately 1.3 KB including both request and response. This is converted into emissions using the [data transfer methodology](./data_transfer.md).
+In addition, we model the average data transfer per cookie sync, approximately 1.3 KB including both request and response. This is converted into emissions using the [data transfer methodology](./data_transfer).
 
 ## Ad Tech Platform Participation and Emissions Allocation
 

--- a/docs/creative.mdx
+++ b/docs/creative.mdx
@@ -6,27 +6,27 @@ The lifecycle of a creative starts with its production. Depending on the channel
 
 The use phase of a creative has three areas of impact:
 
-- The [consumer device](./consumer_devices.md) uses energy to display the creative
-- Energy is used to [transfer](./data_transfer.md) the creative from a server to the device
-- Various [vendors](./ad_tech_model.md) participate in the delivery and reporting of the creative.
+- The [consumer device](./consumer_devices) uses energy to display the creative
+- Energy is used to [transfer](./data_transfer) the creative from a server to the device
+- Various [vendors](./ad_tech_model) participate in the delivery and reporting of the creative.
 
 ### Consumer Device Emissions
 
 The energy used by the consumer during the display of the creative is determined by multiplying the duration of the creative by the energy use of the consumer device.
 
-For instance, a 30 second video ad played on a television will use 0.73 Wh of energy and an allocation of 0.63 gCO2e from the production of the television (see [consumer device methodology](./consumer_devices.md) for details on these numbers).
+For instance, a 30 second video ad played on a television will use 0.73 Wh of energy and an allocation of 0.63 gCO2e from the production of the television (see [consumer device methodology](./consumer_devices) for details on these numbers).
 
 For a banner or native ad that does not have an inherent duration and does not generally use the full screen, we assume a 1 second duration based on the MRC viewability standard.
 
 ### Data Transfer Emissions
 
-For video creatives, we use a slightly modified version of the the Carbon Trust "Power Model" to calculate emissions as described in the [data transfer methodology](./data_transfer.md). This uses the duration, network type, and device type to calculate the marginal impact of the creative on network infrastructure.
+For video creatives, we use a slightly modified version of the the Carbon Trust "Power Model" to calculate emissions as described in the [data transfer methodology](./data_transfer). This uses the duration, network type, and device type to calculate the marginal impact of the creative on network infrastructure.
 
-For banner and text ads, we use the conventional model based on the payload of a creative (the number of bytes transferred to display the ad). We calculate the energy used per GB from the [data transfer methodology](./data_transfer.md) based on the network type.
+For banner and text ads, we use the conventional model based on the payload of a creative (the number of bytes transferred to display the ad). We calculate the energy used per GB from the [data transfer methodology](./data_transfer) based on the network type.
 
 ### Vendor Emissions
 
-For each vendor that participates in delivering and tracking the creative, we need to calculate the emissions per creative delivery request. This is part of the [ad tech vendor methodology](./ad_tech_model.md).
+For each vendor that participates in delivering and tracking the creative, we need to calculate the emissions per creative delivery request. This is part of the [ad tech vendor methodology](./ad_tech_model).
 
 ## Input parameters
 

--- a/docs/publisher_model.mdx
+++ b/docs/publisher_model.mdx
@@ -30,7 +30,7 @@ We model ad tech in three steps:
 
 1. Determine the waterfall used by the publisher so we can differentiate direct buys from programmatic buys, including the number of auctions run at each stage
 2. Determine the ad tech graph
-3. Use the [Ad Tech Platform Model](ad_tech_model.md) to determine emissions for each ad tech platform
+3. Use the [Ad Tech Platform Model](./ad_tech_model) to determine emissions for each ad tech platform
 
 ### The Monetization Waterfall
 
@@ -77,7 +77,7 @@ To calculate the _Lifecycle Emissions Per Second of Use_ (LEPS), we multiply the
 
 `LEPS = PEPS + GI • UEPS`
 
-See [consumer device emissions](./consumer_devices.md) for details on how we calculate the UEPS and PEPS for each device type.
+See [consumer device emissions](./consumer_devices) for details on how we calculate the UEPS and PEPS for each device type.
 
 We multiply the LEPS by the average session time for each property to find the lifecycle emissions per session.
 
@@ -85,7 +85,7 @@ As an example, SimilarWeb shows [BZ](https://www.similarweb.com/website/bz-berli
 
 ### Assessing the carbon footprint of network traffic
 
-See [Emissions from data transfer](./data_transfer.md).
+See [Emissions from data transfer](./data_transfer).
 
 ### Grid mix
 
@@ -101,7 +101,7 @@ We do this by calculating corporate emissions per month and dividing by the numb
 
 ### Calculating corporate emissions
 
-See [Corporate Emissions](./corporate_model.md)
+See [Corporate Emissions](./corporate_model)
 
 ### Allocation of corporate emissions by channel and business model
 


### PR DESCRIPTION
Since the move to Mintlify, most links to other documentation pages were broken. I fixed these through this PR.