### PR TITLE
Fix API response model decimal serialization

### DIFF
--- a/scope3_methodology/api/response_models.py
+++ b/scope3_methodology/api/response_models.py
@@ -2,16 +2,26 @@
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, PlainSerializer
+from typing_extensions import Annotated
 
 
 class ATPDefaultsResponse(BaseModel):
     """Response for /defaults/atp/{template}"""
 
     template: str
-    corporate_emissions_g_co2e_per_bid_request: Optional[Decimal]
-    adtech_platform_block_rate: Decimal = Decimal("0.0")
-    publisher_block_rate: Decimal = Decimal("0.0")
+    corporate_emissions_g_co2e_per_bid_request: Annotated[
+        Optional[Decimal],
+        PlainSerializer(lambda x: float(x), return_type=float, when_used="json"),
+    ]
+    adtech_platform_block_rate: Annotated[
+        Optional[Decimal],
+        PlainSerializer(lambda x: float(x), return_type=float, when_used="json"),
+    ] = 0.0
+    publisher_block_rate: Annotated[
+        Optional[Decimal],
+        PlainSerializer(lambda x: float(x), return_type=float, when_used="json"),
+    ] = 0.0
 
 
 class PropertyDefaultsResponse(BaseModel):
@@ -19,5 +29,11 @@ class PropertyDefaultsResponse(BaseModel):
 
     channel: str
     template: str
-    corporate_emissions_g_co2e_per_impression: Optional[Decimal]
-    quality_impressions_per_duration_s: Optional[Decimal]
+    corporate_emissions_g_co2e_per_impression: Annotated[
+        Optional[Decimal],
+        PlainSerializer(lambda x: float(x), return_type=float, when_used="json"),
+    ]
+    quality_impressions_per_duration_s: Annotated[
+        Optional[Decimal],
+        PlainSerializer(lambda x: float(x), return_type=float, when_used="json"),
+    ]


### PR DESCRIPTION
Update API response serialize decimals as decimal rather than a string. Docs: https://docs.pydantic.dev/latest/api/standard_library_types/#decimaldecimal 

Before 
<img width="576" alt="Screenshot 2024-01-13 at 7 42 10 PM" src="https://github.com/scope3data/methodology/assets/14263050/e74216a0-c34f-400f-b0fb-b86c1e7553d0">


After
<img width="546" alt="Screenshot 2024-01-13 at 7 41 39 PM" src="https://github.com/scope3data/methodology/assets/14263050/7d5d66b1-b744-4505-a3a3-58a799a4e68e">
