### PR TITLE
Add ATP vendor calls to ad format and creative

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -52,14 +52,20 @@ defaults:
   default_emissions_per_rtdp_request_gco2pm: 0.010000000
   default_image_compression_ratio: 10
   default_network_embodied_emissions_gco2e_per_kb:
+    scope3:
+      fixed: 0.000000000
+      mobile: 0.000000000
     sri:
-      fixed: 0.000000004
-      mobile: 0.000000008
+      fixed: 0.004430000
+      mobile: 0.007970000
   default_time_in_view_seconds: 6
-  default_usage_kwh_per_kb:
+  default_usage_kwh_per_gb:
+    scope3:
+      fixed: 0.030000000
+      mobile: 0.140000000
     sri:
-      fixed: 0.000000069
-      mobile: 0.000000236
+      fixed: 0.068700000
+      mobile: 0.236000000
   default_video_bitrate:
     pc: 8000
     phone: 2500

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -1,5 +1,11 @@
 # AUTO_GENERATED from docs/snippets
 defaults:
+  default_audio_bitrate:
+    pc: 160
+    phone: 160
+    smart-speaker: 160
+    tablet: 160
+    tv: 160
   default_baseload_watts:
     fixed: 9.550000000
     mobile: 1.200000000
@@ -72,4 +78,10 @@ defaults:
     tablet: 5000
     tv: 8000
   default_video_bitrate_non_primary: 2500
+  default_video_player_download_trigger:
+    app: impression
+    ctv-bvod: impression
+    dooh: play
+    social: impression
+    web: impression
   default_video_player_size_bytes: 192205

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -32,7 +32,7 @@ defaults:
       pc: 53.200000000
       phone: 0.770000000
       smart-speaker: 2.500000000
-      tablet: 3
+      tablet: 3.000000000
       tv: 87.400000000
     sri:
       pc: 29.400000000
@@ -47,6 +47,9 @@ defaults:
   default_dynamic_watts_per_kbps:
     fixed: 30
     mobile: 1530
+  default_emissions_per_bid_request_gco2pm: 0.114420000
+  default_emissions_per_creative_request_gco2pm: 0.010000000
+  default_emissions_per_rtdp_request_gco2pm: 0.010000000
   default_image_compression_ratio: 10
   default_network_embodied_emissions_gco2e_per_kb:
     sri:

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -113,9 +113,9 @@ Product carousel
 
 | Field                                           | Description |
 | ----------------------------------------------- | ------------------------------------------------------------ |
-| `emissions_per_creative_request_gco2pm` 				| Adjusted, allocated emissions per creative request |
-| `emissions_per_bid_request_gco2pm` 				      | Adjusted, allocated emissions per bid request |
-| `emissions_per_rtdp_request_gco2pm` 				    | Adjusted, allocated emissions per rtdp request |
+| `emissions_per_creative_request_per_geo_gco2pm` | Adjusted, allocated emissions per creative request by continent (NAMER, LATAM, EMEA, JAPAC) |
+| `emissions_per_bid_request_per_geo_gco2pm` 			| Adjusted, allocated emissions per bid request by continent (NAMER, LATAM, EMEA, JAPAC) |
+| `emissions_per_rtdp_request_per_geo_gco2pm` 		| Adjusted, allocated emissions per rtdp request by continent (NAMER, LATAM, EMEA, JAPAC) |
 | `bidders`                            		        | Array of ad platforms that are sent bid requests |
 | `real_time_data_providers`                      | Array of ad platforms that are sent real-time data requests (not propagated) |
 | `distribution_rate_by_bidder_by_country`        | Traffic shaping data for each bidder by country (eg `'xandr.com', 'US', 0.58`)
@@ -237,7 +237,7 @@ creative_data_transfer_bytes =
 
 creative_data_transfer_usage_emissions_gco2pm =
       creative_data_transfer_bytes / 1024 x
-      default_usage_kwh_per_kb[network_type] x
+      default_usage_kwh_per_gb[network_type] / 1000000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
 creative_data_transfer_embodied_emissions_gco2pm =
@@ -308,7 +308,7 @@ creative_data_transfer_embodied_emissions_gco2pm =
 ```
 creative_platform_emissions_gco2pm = 0
 for platform in [creative.ad_platforms, ad_format.ad_platforms]:
-  creative_platform_emissions_gco2pm += platform.emissions_per_creative_request_gco2pm
+  creative_platform_emissions_gco2pm += platform.emissions_per_creative_request_per_geo_gco2pm
 ```
 
 ### Creative Delivery - Consumer Device
@@ -366,7 +366,7 @@ For all channels other than CTV/BVOD, use the conventional model:
 ```
 media_data_transfer_usage_emissions_gco2pm =
       property.average_data_kb_per_session_ex_ads x
-      default_usage_kwh_per_kb[network_type] x
+      default_usage_kwh_per_gb[network_type] / 1000000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
 media_data_transfer_embodied_emissions_gco2pm =
@@ -414,10 +414,10 @@ media_corporate_emissions_gco2pm =
 
 ```
 get_platform_emissions(ad_platform):
-  direct_emissions = emissions_per_bid_request_gco2pm
+  direct_emissions = emissions_per_bid_request_per_geo_gco2pm
   rtdp_emissions = 0
   for rtdp in ad_platform.real_time_data_providers:
-		rtdp_emissions += emissions_per_rtdp_request_gco2pm
+		rtdp_emissions += emissions_per_rtdp_request_per_geo_gco2pm
   bidder_emissions = 0
   for bidder in ad_platform.bidders:
       bidder_emissions += get_platform_emissions(bidder) x

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -53,7 +53,6 @@ import AdPlatformDefaults from '/snippets/defaults_ad_platform.mdx'
 | ----------------------------------- | -------------------------------------------------------------------------------------------- |
 | `rendered_width_pixels`             | Width of the creative when rendered. Leave blank for responsive (will assume screen width)	 |
 | `rendered_height_pixels`	          | Height of the creative when rendered. Leave blank for responsive (will assume screen height) |
-| `is_primary_experience`	            | Is the ad the primary experience for the user (takeover/interstitial)                        |
 | `image_sizes` 	                    | Array of image dimensions (eg `["300x250", "70x70"]`)                                        |
 | `audio_duration_seconds`	          | Audio duration (if applicable)                                                               |
 | `video_duration_seconds`	          | Video duration (if applicable)                                                               |
@@ -69,7 +68,6 @@ import AdPlatformDefaults from '/snippets/defaults_ad_platform.mdx'
 image_sizes = ['300x250']
 rendered_width_pixels = 300,
 rendered_height_pixels = 250
-is_primary_experience = false
 ```
 
 30 second audio
@@ -85,7 +83,6 @@ video_duration_seconds = 15;
 video_player = 'default',
 rendered_width_pixels = 500,
 rendered_height_pixels = 400
-is_primary_experience = false
 ```
 
 Product carousel
@@ -95,7 +92,6 @@ Product carousel
   other_assets_bytes = 7321,
   rendered_height_pixels = 600,
   rendered_width_pixels = 450
-  is_primary_experience = false
 ```
 
 ### Property
@@ -262,8 +258,9 @@ image_bytes = SUM(image_sizes[n].width x image_sizes[n].height) x 3 / default_im
 audio_duration = creative_audio_duration_seconds ?? ad_format.audio_duration_seconds
 audio_bytes = audio_duration_seconds x default_audio_bitrate[device_type]
 
+is_primary_experience = !ad_format.rendered_width_pixels && !ad_format.rendered_height_pixels
 default_bitrate =
-      ad_format.is_primary_experience ?
+      is_primary_experience ?
       default_video_bitrate[device_type] :
       default_video_bitrate_non_primary
 bitrate =
@@ -324,7 +321,7 @@ device_pixels = default_device_width[device_type] x default_device_height[device
 rendered_width = ad_format.rendered_width_pixels ?? default_device_width[device_type]
 rendered_height = ad_format.rendered_height_pixels ?? default_device_height[device_type]
 visual_device_coverage =
-      ad_format.is_primary_experience ?
+      is_primary_experience ?
       device_pixels :
       rendered_width x rendered_height / device_pixels
 time_in_view =

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -142,8 +142,7 @@ Product carousel
 | `creative_ad_format`                 | Either a basic or vendor-provided ad format |
 | `creative_ad_platforms`              | Ad serving, verification, and measurement ad platforms wrapping or embedded in the creative |
 | `creative_image_data_transfer_bytes` | Data transfer for the video itself , ideally measured by the CDN |
-| `creative_image_width_pixels`        | Width of creative (basic image only) |
-| `creative_image_height_pixels`       | Height of creative (basic image only) |
+| `creative_image_sizes`               | Array of image sizes included in the creative |
 | `creative_audio_data_transfer_bytes` | Data transfer for the core audio asset, ideally measured by the CDN |
 | `creative_audio_duration_seconds`    | Audio duration in seconds |
 | `creative_video_data_transfer_bytes` | Data transfer for the core video asset, ideally measured by the CDN |
@@ -256,6 +255,7 @@ audio_bytes = creative_audio_data_transfer_bytes
 Otherwise, calculate data transfer:
 
 ```
+image_sizes = creative_image_sizes ? ad_format.image_sizes
 image_bytes = SUM(image_sizes[n].width x image_sizes[n].height) x 3 / default_image_compression_ratio
 
 audio_duration = creative_audio_duration_seconds ?? ad_format.audio_duration_seconds

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -112,10 +112,12 @@ Product carousel
 
 | Field                                           | Description |
 | ----------------------------------------------- | ------------------------------------------------------------ |
-| `allocated_adjusted_corporate_emissions_kgco2e` | This ad platform's share of corporate emissions |
-| `total_decisioning_requests`                    | Total ad opportunities decisioned (ie, imps bid upon) |
-| `downstream_ad_platforms`                       | Array of ad platforms that are sent requests |
-| `distribution_rate_by_platform`                 | Traffic shaping data for each downstream ad platform |
+| `emissions_per_creative_request_gco2pm` 				| Adjusted, allocated emissions per creative request |
+| `emissions_per_bid_request_gco2pm` 				      | Adjusted, allocated emissions per bid request |
+| `emissions_per_rtdp_request_gco2pm` 				    | Adjusted, allocated emissions per rtdp request |
+| `bidders`                            		        | Array of ad platforms that are sent bid requests |
+| `real_time_data_providers`                      | Array of ad platforms that are sent real-time data requests (not propagated) |
+| `distribution_rate_by_bidder_by_country`        | Traffic shaping data for each bidder by country (eg `'xandr.com', 'US', 0.58`)
 
 ### Placement
 
@@ -138,6 +140,7 @@ Product carousel
 | `network_type`                       | See [network types](#network-types) |
 | `property`                           | See [property](#property) |
 | `creative_ad_format`                 | Either a basic or vendor-provided ad format |
+| `creative_ad_platforms`              | Ad serving, verification, and measurement ad platforms wrapping or embedded in the creative |
 | `creative_image_data_transfer_bytes` | Data transfer for the video itself , ideally measured by the CDN |
 | `creative_image_width_pixels`        | Width of creative (basic image only) |
 | `creative_image_height_pixels`       | Height of creative (basic image only) |
@@ -148,7 +151,7 @@ Product carousel
 | `creative_video_bitrate_kbps`        | Video bitrate *as delivered* in kilobits per second |
 | `creative_video_size_bytes`          | Video size *as delivered* in bytes |
 | `creative_video_duration_seconds`    | Video duration in seconds |
-| `creative_video_view_time`           | Average time, in seconds, that a video is viewed |
+| `creative_video_view_time_seconds`   | Average time, in seconds, that a video is viewed |
 | `creative_video_view_rate`           | Average percentage of a video that is viewed |
 | `creative_time_in_view_seconds`      | Time that the creative was visible on the device |
 
@@ -299,6 +302,14 @@ creative_data_transfer_embodied_emissions_gco2pm =
       default_network_embodied_emissions_gco2e_per_kb[network_type]
 ```
 
+### Creative Delivery - Platform
+
+```
+creative_platform_emissions_gco2pm = 0
+for platform in [creative.ad_platforms, ad_format.ad_platforms]:
+  creative_platform_emissions_gco2pm += platform.emissions_per_creative_request_gco2pm
+```
+
 ### Creative Delivery - Consumer Device
 
 ```
@@ -398,29 +409,31 @@ media_corporate_emissions_gco2pm =
       property.average_imps_per_session
 ```
 
-### Ad Selection
+### Ad Selection - Platform
 
 ```
 get_platform_emissions(ad_platform):
-  direct_emissions = 
-      ad_platform.allocated_adjusted_corporate_emissions_kg * 1000 /
-      ad_platform.total_decisioning_requests
-  indirect_emissions = 0
-  for platform in ad_platform.downstream_platforms:
-      indirect_emissions += get_platform_emissions(platform) x
-            ad_platform.distribution_rate_by_platform[platform] ?? 1
+  direct_emissions = emissions_per_bid_request_gco2pm
+  rtdp_emissions = 0
+  for rtdp in ad_platform.real_time_data_providers:
+		rtdp_emissions += emissions_per_rtdp_request_gco2pm
+  bidder_emissions = 0
+  for bidder in ad_platform.bidders:
+      bidder_emissions += get_platform_emissions(bidder) x
+            ad_platform.distribution_rate_by_bidder_by_country[country, bidder] ?? 1
+  return direct_emissions + rtdp_emissions + bidder_emissions
 
 ad_selection_platform_emissions_gco2pm = 0
 data_transfer_bytes = 0
 for platform in placement.ad_platforms:
   ad_selection_platform_emissions_gco2pm += get_platform_emissions(platform)
   data_transfer_bytes += default_consumer_device_request_size_bytes[channel]
+```
 
+### Ad Selection - Data Transfer
+
+```
 ad_selection_data_transfer_emissions_gco2pm =
     data_transfer_bytes / 1024 x
     lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
-
-ad_selection_emissions_gco2pm =
-    ad_selection_platform_emissions_gco2pm +
-    ad_selection_data_transfer_emissions_gco2pm
 ```

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -130,9 +130,9 @@ Product carousel
 
 | Field                                | Description |
 | ------------------------------------ | ---------------------------------- |
-| `impressions`                        | The number of impressions counted |
+| `impressions`                        | The number of impressions counted (required for all channels other than DOOH) |
 | `views`                              | The number of views counted  |
-| `plays`                              | The number of plays |
+| `plays`                              | The number of plays (required for DOOH) |
 | `utc_datetime`                       | Date and time, in UTC, when impressions were delivered |
 | `country`                            | The country where the impression was delivered |
 | `region`                             | The region of the country where the impression was delivered |

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -59,6 +59,7 @@ import AdPlatformDefaults from '/snippets/defaults_ad_platform.mdx'
 | `video_duration_seconds`	          | Video duration (if applicable)                                                               |
 | `video_player`	                    | Video player used to render video (if applicable)                                            |
 | `other_assets_bytes`	              | Metadata, text, html, etc                                                                    |
+| `ad_platforms`                      | Ad serving, verification, and measurement ad platforms wrapping or embedded in the ad format |
 
 #### Sample Ad Formats:
 

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -1,9 +1,13 @@
 ```
 default_consumer_device_request_size_bytes:
-  web: 1500
-  app: 1000
+  web:      1500
+  app:      1000
   ctv-bvod: 0
-  dooh: 0
-  audio: 1000
-  social: 1000
+  dooh:     0
+  audio:    1000
+  social:   1000
+
+default_emissions_per_creative_request_gco2pm: 0.01
+default_emissions_per_bid_request_gco2pm:      0.11442
+default_emissions_per_rtdp_request_gco2pm:     0.01
 ```

--- a/docs/snippets/defaults_consumer_device.mdx
+++ b/docs/snippets/defaults_consumer_device.mdx
@@ -1,26 +1,26 @@
 ```
 default_device_watts:
   scope3:
-    phone: 0.77
-    pc: 53.2
-    tablet: 3
-    tv: 87.4
-    smart-speaker: 2.5
+    phone:          0.77
+    pc:            53.2
+    tablet:         3.0
+    tv:            87.4
+    smart-speaker:  2.5
   sri:
-    phone: 2.856
-    pc: 29.4
-    tablet: 29.4
-    tv: 81.6
+    phone:          2.856
+    pc:            29.4
+    tablet:        29.4
+    tv:            81.6
 default_device_embodied_emissions_per_second:
   scope3:
-    phone: 0.0058
-    pc: 0.007
-    tablet: 0.0029
-    tv: 0.0096
-    smart-speaker: 0.0061
+    phone:          0.0058
+    pc:             0.007
+    tablet:         0.0029
+    tv:             0.0096
+    smart-speaker:  0.0061
   sri:
-    phone: .00946
-    pc: .0132
-    tablet: .0128
-    tv: .00889
+    phone:          0.00946
+    pc:             0.0132
+    tablet:         0.0128
+    tv:             0.00889
 ```

--- a/docs/snippets/defaults_conventional_model.mdx
+++ b/docs/snippets/defaults_conventional_model.mdx
@@ -1,10 +1,10 @@
 ```
 default_usage_kwh_per_kb:
   sri:
-    fixed: 6.87E-08
+    fixed:  6.87E-08
     mobile: 2.36E-07
 default_network_embodied_emissions_gco2e_per_kb:
   sri:
-    fixed: 4.43E-09
+    fixed:  4.43E-09
     mobile: 7.97E-09
 ```

--- a/docs/snippets/defaults_conventional_model.mdx
+++ b/docs/snippets/defaults_conventional_model.mdx
@@ -1,10 +1,16 @@
 ```
-default_usage_kwh_per_kb:
+default_usage_kwh_per_gb:
+  scope3:
+    fixed:  0.03
+    mobile: 0.14
   sri:
-    fixed:  6.87E-08
-    mobile: 2.36E-07
+    fixed:  0.0687
+    mobile: 0.236
 default_network_embodied_emissions_gco2e_per_kb:
+  scope3:
+    fixed:  0.00
+    mobile: 0.00
   sri:
-    fixed:  4.43E-09
-    mobile: 7.97E-09
+    fixed:  0.00443
+    mobile: 0.00797
 ```

--- a/docs/snippets/defaults_device_size.mdx
+++ b/docs/snippets/defaults_device_size.mdx
@@ -1,12 +1,12 @@
 ```
 default_device_width:
-  phone: 1080
+  phone:  1080
   tablet: 1536
-  pc: 2560
-  tv: 1920
+  pc:     2560
+  tv:     1920
 default_device_height:
-  phone: 1920
+  phone:  1920
   tablet: 2048
-  pc: 1440
-  tv: 1080
+  pc:     1440
+  tv:     1080
 ```

--- a/docs/snippets/defaults_media_size.mdx
+++ b/docs/snippets/defaults_media_size.mdx
@@ -6,4 +6,10 @@ default_video_bitrate:
   tablet:          5000
   pc:              8000
   tv:              8000
+default_audio_bitrate:
+  phone:            160
+  tablet:           160
+  pc:               160
+  tv:               160
+  smart-speaker:    160
 ```

--- a/docs/snippets/defaults_media_size.mdx
+++ b/docs/snippets/defaults_media_size.mdx
@@ -2,8 +2,8 @@
 default_image_compression_ratio:   10
 default_video_bitrate_non_primary: 2500
 default_video_bitrate:
-  phone: 			   2500
-  tablet: 			   5000
-  pc:     			   8000
-  tv:     			   8000
+  phone:           2500
+  tablet:          5000
+  pc:              8000
+  tv:              8000
 ```

--- a/docs/snippets/defaults_media_size.mdx
+++ b/docs/snippets/defaults_media_size.mdx
@@ -1,9 +1,9 @@
 ```
-default_image_compression_ratio: 10
+default_image_compression_ratio:   10
 default_video_bitrate_non_primary: 2500
 default_video_bitrate:
-  phone: 2500
-  tablet: 5000
-  pc: 8000
-  tv: 8000
+  phone: 			   2500
+  tablet: 			   5000
+  pc:     			   8000
+  tv:     			   8000
 ```

--- a/docs/snippets/defaults_power_model.mdx
+++ b/docs/snippets/defaults_power_model.mdx
@@ -1,8 +1,8 @@
 ``` 
 default_baseload_watts:
-  fixed: 9.55
+  fixed:  9.55
   mobile: 1.2                             
 default_dynamic_watts_per_kbps:
-  fixed: 30
+  fixed:    30
   mobile: 1530 
 ```

--- a/docs/snippets/defaults_power_model.mdx
+++ b/docs/snippets/defaults_power_model.mdx
@@ -1,7 +1,7 @@
 ``` 
 default_baseload_watts:
-  fixed:  9.55
-  mobile: 1.2                             
+  fixed:     9.55
+  mobile:    1.2                             
 default_dynamic_watts_per_kbps:
   fixed:    30
   mobile: 1530 

--- a/docs/snippets/defaults_video_player.mdx
+++ b/docs/snippets/defaults_video_player.mdx
@@ -1,3 +1,9 @@
 ```
 default_video_player_size_bytes: 192205
+default_video_player_download_trigger:
+  web:      'impression'
+  app:      'impression'
+  ctv-bvod: 'impression'
+  dooh:     'play'
+  social:   'impression'
 ```

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -238,7 +238,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 14)
+        self.assertEqual(len(docs_defs), 17)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -238,7 +238,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 17)
+        self.assertEqual(len(docs_defs), 19)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
Creatives and ad formats have 0 or more ad tech platforms (ad server, brand safety, etc) on each request.
Update ad platform to include RTDP requests and simplify emissions calcs.
Clean up formatting on snippets