### PR TITLE
add channel mapping assumptions

### DIFF
--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -1,0 +1,31 @@
+```
+default_channel_by_device:
+  phone:
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
+  tablet:
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
+  pc:
+    - ctv-bvod
+    - social
+    - audio
+    - web
+  tv:
+    - ctv-bvod
+    - app
+  smart-speaker:
+    - audio
+default_device_by_channel:
+  social:   phone
+  ctv-bvod: tv
+  audio:    phone
+  app:      phone
+  web:      pc
+```


### PR DESCRIPTION
What happens if channel, ad format, and device type are not all specified?