### PR TITLE
Update default_emissions_per_creative_request_gco2pm

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -83,7 +83,7 @@ defaults:
     fixed: 0.030000000
     mobile: 1.530000000
   default_emissions_per_bid_request_gco2pm: 0.114420000
-  default_emissions_per_creative_request_gco2pm: 0.010000000
+  default_emissions_per_creative_request_gco2pm: 0.000300000
   default_emissions_per_rtdp_request_gco2pm: 0.010000000
   default_image_compression_ratio: 10
   default_network_embodied_emissions_gco2e_per_kb:

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -7,7 +7,7 @@ default_consumer_device_request_size_bytes:
   audio:    1000
   social:   1000
 
-default_emissions_per_creative_request_gco2pm: 0.01
+default_emissions_per_creative_request_gco2pm: 0.0003
 default_emissions_per_bid_request_gco2pm:      0.11442
 default_emissions_per_rtdp_request_gco2pm:     0.01
 


### PR DESCRIPTION
I've set this at 0.0003 which would make it on the high end. 

We should always typically pick the geo since we've covered most regions - but in the case we don't know the geo we would use the more conservative approach 