### PR TITLE
bug:Fixed network embodied emissions defaults

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -11,27 +11,27 @@ defaults:
     mobile: 1.200000000
   default_channel_by_device:
     pc:
-      - ctv-bvod
-      - social
-      - audio
-      - web
+    - ctv-bvod
+    - social
+    - audio
+    - web
     phone:
-      - social
-      - ctv-bvod
-      - audio
-      - app
-      - web
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
     smart-speaker:
-      - audio
+    - audio
     tablet:
-      - social
-      - ctv-bvod
-      - audio
-      - app
-      - web
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
     tv:
-      - ctv-bvod
-      - app
+    - ctv-bvod
+    - app
   default_consumer_device_request_size_bytes:
     app: 1000
     audio: 1000
@@ -91,8 +91,8 @@ defaults:
       fixed: 0.000000000
       mobile: 0.000000000
     sri:
-      fixed: 0.004430000
-      mobile: 0.007970000
+      fixed: 0.000004430
+      mobile: 0.000007970
   default_non_primary_video_bitrate_kbps: 2500
   default_percent_mobile:
     scope3: 23.600000000

--- a/docs/snippets/defaults_conventional_model.mdx
+++ b/docs/snippets/defaults_conventional_model.mdx
@@ -11,6 +11,6 @@ default_network_embodied_emissions_gco2e_per_kb:
     fixed:  0.00
     mobile: 0.00
   sri:
-    fixed:  0.00443
-    mobile: 0.00797
+    fixed:  0.00000443
+    mobile: 0.00000797
 ```


### PR DESCRIPTION
There was a unit conversion error when copying the defaults from the [sri methodology file](https://github.com/SRISyndicatRegiesInternet/SRIxAD-DigitalCampaignsCarbonFramework/releases/download/v2.1.0/Referentiel.SRI.x.AD.-.V2.1_partage.zip).

The numbers for embodied emissions per byte of data transfer were off by a factor of a thousand, the number given in the SRI methodology for fixed network is 4.43 E-9 kg/kb which converts to 4.43 E-6 g/kb, the number in our methodology page was 4.43 E-3 so a thousand times that. THe error was probably caused from a weird phrasing in the methodology file where the unit is clearly specified as kg/kb but the origin field says it comes from the ADEME_220830_v1.4 number for emissionf per GB of data transfer, the french version of the file explicitly says that the number has been converted to kg/kb.