### PR TITLE
Added generic ad server emissions default

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -82,6 +82,7 @@ defaults:
   default_dynamic_watts_per_mbps:
     fixed: 0.030000000
     mobile: 1.530000000
+  default_emissions_generic_ad_server: 0.000016000
   default_emissions_per_bid_request_gco2pm: 0.114420000
   default_emissions_per_creative_request_gco2pm: 0.000300000
   default_emissions_per_rtdp_request_gco2pm: 0.010000000

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -10,6 +10,7 @@ default_consumer_device_request_size_bytes:
 default_emissions_per_creative_request_gco2pm: 0.0003
 default_emissions_per_bid_request_gco2pm:      0.11442
 default_emissions_per_rtdp_request_gco2pm:     0.01
+default_emissions_generic_ad_server: 0.000016
 
 generic_creative_ad_server:
   emissions_per_creative_request_per_geo_gco2pm:

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 26)
+        self.assertEqual(len(docs_defs), 27)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
Added the value for our generic ad server, Niki and I decided to go with the value we had previously calculated for private ad servers for now and maybe switch to the 80th percentile of ad servers once we have a more representative sample, the logic is as in: https://www.notion.so/scope3/Add-generic-ad-server-to-all-containers-ca86e9376426432c85f1708a343eaa0e?pvs=4