### PR TITLE
feat: No network default yes emboddied emissions

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -99,10 +99,6 @@ defaults:
   default_emissions_per_creative_request_gco2pm: 0.000300000
   default_emissions_per_rtdp_request_gco2pm: 0.010000000
   default_image_compression_ratio: 10
-  default_network_by_device:
-    pc: fixed
-    smart-speaker: fixed
-    tv: fixed
   default_network_embodied_emissions_gco2e_per_kb:
     scope3:
       fixed: 0.000000000

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -239,7 +239,7 @@ defaults:
     ctv-bvod: 15s Video
     dooh: Landscape - 1920x1080 Image
     social: Sponsored Post - 1080x1920 Image
-    web: Leaderboard - 728x90 Banner
+    web: Leaderboard - 970x250 Banner
   default_property_ad_funded_percentage_by_channel:
     app: 1
     audio: 1

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -101,8 +101,8 @@ defaults:
   default_image_compression_ratio: 10
   default_network_embodied_emissions_gco2e_per_kb:
     scope3:
-      fixed: 0.000000000
-      mobile: 0.000000000
+      fixed: 0.000004430
+      mobile: 0.000007970
     sri:
       fixed: 0.000004430
       mobile: 0.000007970

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -239,7 +239,7 @@ defaults:
     ctv-bvod: 15s Video
     dooh: Landscape - 1920x1080 Image
     social: Sponsored Post - 1080x1920 Image
-    web: Leaderboard - 970x250 Banner
+    web: Leaderboard - 728x90 Banner
   default_property_ad_funded_percentage_by_channel:
     app: 1
     audio: 1

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -173,10 +173,6 @@ From [Carbon impact of video streaming (Carbon Trust)](https://ctprodstorageacco
 
 <PowerModelDefaults />
 
-To determine network when it's not submitted we default to fixed for pc, tv and smart speakers.
-When we don't know the device or the device is a phone or tablet we calculate network costs as a weighted average of the
-fixed and mobile usage in the country (if available) or worldwide.
-
 ### Mobile to fixed ratios by country
 
 From [ITU Data Hub](https://datahub.itu.int/) (2022 data)

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -173,6 +173,10 @@ From [Carbon impact of video streaming (Carbon Trust)](https://ctprodstorageacco
 
 <PowerModelDefaults />
 
+To determine network when it's not submitted we default to fixed for pc, tv and smart speakers.
+When we don't know the device or the device is a phone or tablet we calculate network costs as a weighted average of the
+fixed and mobile usage in the country (if available) or worldwide.
+
 ### Mobile to fixed ratios by country
 
 From [ITU Data Hub](https://datahub.itu.int/) (2022 data)

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -235,8 +235,7 @@ Providers should clearly and publicly document:
 We use all data we have available on every single request but in many situations we may lack some information, for this
 we have a series of fallbacks to be able to provide reasonable estimates in most situations.
 
-To determine network when it's not submitted we default to fixed for pc, tv and smart speakers.
-When we don't know the device or the device is a phone or tablet we calculate costs associated to network type
+To determine network when it's not submitted we calculate costs associated to network type
 as a weighted average of the fixed and mobile usage in the country (if available) or worldwide.
 
 We can also generally determine the channel from the property or when that is ambiguous but we have device information

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -43,12 +43,11 @@ default_platform_ad_format_by_channel:
   app:      Interstitial - 1080x1920 Banner
   web:      Leaderboard - 970x250 Banner
 default_property_average_imps_per_session_by_channel:
-  dooh:     1
-  social:   1
-  ctv-bvod: 1
-  audio:    1
-  app:      1
-  web:      1
+  social:   19.5
+  ctv-bvod: 8.256
+  audio:    4.8
+  app:      18.8
+  web:      35.3
 default_property_ad_funded_percentage_by_channel:
   dooh:     1
   social:   1
@@ -57,12 +56,11 @@ default_property_ad_funded_percentage_by_channel:
   app:      1
   web:      1
 default_average_seconds_per_session_excluding_ads_by_channel:
-  dooh:     1
-  social:   1
-  ctv-bvod: 1
-  audio:    1
-  app:      1
-  web:      1
+  social:   238
+  ctv-bvod: 2580
+  audio:    1500
+  app:      137.8
+  web:      353
 default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
   social:   9745
   ctv-bvod: 20640

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -41,7 +41,7 @@ default_platform_ad_format_by_channel:
   ctv-bvod: 15s Video
   audio:    30s Audio
   app:      Interstitial - 1080x1920 Banner
-  web:      Leaderboard - 970x250 Banner
+  web:      Leaderboard - 728x90 Banner
 default_property_average_imps_per_session_by_channel:
   social:   19.5
   ctv-bvod: 8.256

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -35,12 +35,20 @@ default_platform_ad_format_by_channel:
   audio:    30s Audio
   app:      Interstitial - 1080x1920 Banner
   web:      Leaderboard - 728x90 Banner
+default_platform_ad_format_by_channel:
+  dooh:     Landscape - 1920x1080 Image
+  social:   Sponsored Post - 1080x1920 Image
+  ctv-bvod: 15s Video
+  audio:    30s Audio
+  app:      Interstitial - 1080x1920 Banner
+  web:      Leaderboard - 970x250 Banner
 default_property_average_imps_per_session_by_channel:
-  social:   19.5
-  ctv-bvod: 8.256
-  audio:    4.8
-  app:      18.8
-  web:      35.3
+  dooh:     1
+  social:   1
+  ctv-bvod: 1
+  audio:    1
+  app:      1
+  web:      1
 default_property_ad_funded_percentage_by_channel:
   dooh:     1
   social:   1
@@ -49,11 +57,12 @@ default_property_ad_funded_percentage_by_channel:
   app:      1
   web:      1
 default_average_seconds_per_session_excluding_ads_by_channel:
-  social:   238
-  ctv-bvod: 2580
-  audio:    1500
-  app:      137.8
-  web:      353
+  dooh:     1
+  social:   1
+  ctv-bvod: 1
+  audio:    1
+  app:      1
+  web:      1
 default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
   social:   9745
   ctv-bvod: 20640

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -35,13 +35,6 @@ default_platform_ad_format_by_channel:
   audio:    30s Audio
   app:      Interstitial - 1080x1920 Banner
   web:      Leaderboard - 728x90 Banner
-default_platform_ad_format_by_channel:
-  dooh:     Landscape - 1920x1080 Image
-  social:   Sponsored Post - 1080x1920 Image
-  ctv-bvod: 15s Video
-  audio:    30s Audio
-  app:      Interstitial - 1080x1920 Banner
-  web:      Leaderboard - 728x90 Banner
 default_property_average_imps_per_session_by_channel:
   social:   19.5
   ctv-bvod: 8.256

--- a/docs/snippets/defaults_conventional_model.mdx
+++ b/docs/snippets/defaults_conventional_model.mdx
@@ -8,8 +8,8 @@ default_usage_kwh_per_gb:
     mobile: 0.236
 default_network_embodied_emissions_gco2e_per_kb:
   scope3:
-    fixed:  0.00
-    mobile: 0.00
+    fixed:  0.00000443
+    mobile: 0.00000797
   sri:
     fixed:  0.00000443
     mobile: 0.00000797

--- a/docs/snippets/defaults_network_traffic.mdx
+++ b/docs/snippets/defaults_network_traffic.mdx
@@ -1,8 +1,4 @@
 ```
-default_network_by_device:
-  pc:     fixed
-  tv:     fixed
-  smart-speaker: fixed
 default_percent_mobile:
   scope3: 23.6
   sri:    10.0

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 33)
+        self.assertEqual(len(docs_defs), 32)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
Two minor updates resulting from today's discussion in the API V2 stand up:

- Removed the language and defaults around using fixed network as the fallback for tvs, pcs and smartspeakers. Rationalle is that those considerations are already embodied in the per country mix and while in the US most home usage (wifi) uses a fixed network in the developing world and rural areas it is often the case that home internet uses a mobile network infrastructure (either satelite or cellular).

- Updated the embodied emissions for data transfer for scope3 (previously 0) to match the numbers estimated by the SRI methodology.  

@ohalushchak-exadel tagging you here so I make sure not to deploy this without your api changes having been deployed (since this would break if you're expecting the default_network_by_device default)