### PR TITLE
fix: updated default names

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -31,27 +31,27 @@ defaults:
     mobile: 1.200000000
   default_channel_by_device:
     pc:
-    - ctv-bvod
-    - social
-    - audio
-    - web
+      - ctv-bvod
+      - social
+      - audio
+      - web
     phone:
-    - social
-    - ctv-bvod
-    - audio
-    - app
-    - web
+      - social
+      - ctv-bvod
+      - audio
+      - app
+      - web
     smart-speaker:
-    - audio
+      - audio
     tablet:
-    - social
-    - ctv-bvod
-    - audio
-    - app
-    - web
+      - social
+      - ctv-bvod
+      - audio
+      - app
+      - web
     tv:
-    - ctv-bvod
-    - app
+      - ctv-bvod
+      - app
   default_consumer_device_request_size_bytes:
     app: 1000
     audio: 1000
@@ -299,8 +299,18 @@ defaults:
       JAPAC: 0.000300000
       LATAM: 0.000100000
       NAMER: 0.000100000
+    emissions_per_creative_request_per_geo_gco2pm:
+      EMEA: 0.000100000
+      JAPAC: 0.000300000
+      LATAM: 0.000100000
+      NAMER: 0.000100000
   generic_measurement_platform:
     emissions_per_creative_request_per_geo_gco2_per_imp:
+      EMEA: 0.000100000
+      JAPAC: 0.000300000
+      LATAM: 0.000100000
+      NAMER: 0.000100000
+    emissions_per_creative_request_per_geo_gco2pm:
       EMEA: 0.000100000
       JAPAC: 0.000300000
       LATAM: 0.000100000

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -6,12 +6,18 @@ defaults:
     smart-speaker: 160
     tablet: 160
     tv: 160
-  default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
+  default_average_data_kb_per_session_excluding_ads_by_channel:
     app: 5525
     audio: 240
     ctv-bvod: 20640
     social: 9745
     streaming-video: 20640
+    web: 1.100000000
+  default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
+    app: 40.096494920
+    audio: 160
+    ctv-bvod: 8000
+    social: 40.946037820
     web: 388
   default_average_seconds_per_session_excluding_ads_by_channel:
     app: 137.800000000
@@ -25,27 +31,27 @@ defaults:
     mobile: 1.200000000
   default_channel_by_device:
     pc:
-      - ctv-bvod
-      - social
-      - audio
-      - web
+    - ctv-bvod
+    - social
+    - audio
+    - web
     phone:
-      - social
-      - ctv-bvod
-      - audio
-      - app
-      - web
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
     smart-speaker:
-      - audio
+    - audio
     tablet:
-      - social
-      - ctv-bvod
-      - audio
-      - app
-      - web
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
     tv:
-      - ctv-bvod
-      - app
+    - ctv-bvod
+    - app
   default_consumer_device_request_size_bytes:
     app: 1000
     audio: 1000
@@ -98,8 +104,11 @@ defaults:
     fixed: 0.030000000
     mobile: 1.530000000
   default_emissions_generic_ad_server: 0.000016000
+  default_emissions_per_bid_request_gco2_per_imp: 0.114420000
   default_emissions_per_bid_request_gco2pm: 0.114420000
+  default_emissions_per_creative_request_gco2_per_imp: 0.000300000
   default_emissions_per_creative_request_gco2pm: 0.000300000
+  default_emissions_per_rtdp_request_gco2_per_imp: 0.010000000
   default_emissions_per_rtdp_request_gco2pm: 0.010000000
   default_image_compression_ratio: 10
   default_network_embodied_emissions_gco2e_per_kb:
@@ -285,13 +294,13 @@ defaults:
     web: impression
   default_video_player_size_bytes: 192205
   generic_creative_ad_server:
-    emissions_per_creative_request_per_geo_gco2pm:
+    emissions_per_creative_request_per_geo_gco2_per_imp:
       EMEA: 0.000100000
       JAPAC: 0.000300000
       LATAM: 0.000100000
       NAMER: 0.000100000
   generic_measurement_platform:
-    emissions_per_creative_request_per_geo_gco2pm:
+    emissions_per_creative_request_per_geo_gco2_per_imp:
       EMEA: 0.000100000
       JAPAC: 0.000300000
       LATAM: 0.000100000

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -252,13 +252,13 @@ defaults:
     streaming-video: 15s Video
     web: Leaderboard - 728x90 Banner
   default_property_ad_funded_percentage_by_channel:
-    app: 1
-    audio: 1
-    ctv-bvod: 1
-    dooh: 1
-    social: 1
-    streaming-video: 1
-    web: 1
+    app: 100
+    audio: 100
+    ctv-bvod: 100
+    dooh: 100
+    social: 100
+    streaming-video: 100
+    web: 100
   default_property_average_imps_per_session_by_channel:
     app: 18.800000000
     audio: 4.800000000

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -14,11 +14,12 @@ defaults:
     streaming-video: 20640
     web: 388
   default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
-    app: 40.096494920
-    audio: 160
-    ctv-bvod: 8000
-    social: 40.946037820
-    web: 1.100000000
+    app: 5525
+    audio: 240
+    ctv-bvod: 20640
+    social: 9745
+    streaming-video: 20640
+    web: 388
   default_average_seconds_per_session_excluding_ads_by_channel:
     app: 137.800000000
     audio: 1500

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -12,13 +12,13 @@ defaults:
     ctv-bvod: 20640
     social: 9745
     streaming-video: 20640
-    web: 1.100000000
+    web: 388
   default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
     app: 40.096494920
     audio: 160
     ctv-bvod: 8000
     social: 40.946037820
-    web: 388
+    web: 1.100000000
   default_average_seconds_per_session_excluding_ads_by_channel:
     app: 137.800000000
     audio: 1500

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -104,6 +104,7 @@ defaults:
     fixed: 0.030000000
     mobile: 1.530000000
   default_emissions_generic_ad_server: 0.000016000
+  default_emissions_generic_ad_server_gco2_per_imp: 0.000016000
   default_emissions_per_bid_request_gco2_per_imp: 0.114420000
   default_emissions_per_bid_request_gco2pm: 0.114420000
   default_emissions_per_creative_request_gco2_per_imp: 0.000300000

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -109,7 +109,7 @@ Native product carousel
 | `average_seconds_per_session_excluding_ads`     | Yes      | The average length of a session on this property excluding ads (eg 44 min of a 60 min TV show) |
 | `average_imps_per_session`                      | Yes      | The average number of impressions per session                                                  |
 | `average_data_kb_per_session_excluding_ads`     | Yes      | The average number of KB transferred during a session excluding ads                            |
-| `ad_funded_percentage`                          | Yes      | The percentage of content funded by advertising (eg 50%)                                       |
+| `ad_funded_percentage`                          | Yes      | 0-100 The percentage of content funded by advertising (eg 50)                                  |
 | `allocated_adjusted_corporate_emissions_kgco2e` | Yes      | This property's share of corporate emissions                                                   |
 | `total_sessions`                                | Yes      | Number of sessions in the same time period as corporate emissions                              |
 
@@ -458,7 +458,7 @@ Determing the session seconds for a single impressions
 ```
 session_seconds_per_imp =
       property.average_seconds_per_session_excluding_ads x
-      property.ad_funded_percentage /
+      property.ad_funded_percentage/100 /
       property.average_imps_per_session
 ```
 
@@ -467,7 +467,7 @@ For all channels other than CTV/BVOD, use the conventional model:
 ```
 media_data_transfer_kb_per_imp =
       property.average_data_kb_per_session_excluding_ads x
-      property.ad_funded_percentage  /
+      property.ad_funded_percentage/100  /
       property.average_imps_per_session
 
 media_data_transfer_usage_emissions_gco2_per_imp =

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -115,16 +115,16 @@ Native product carousel
 
 ### Ad Platform
 
-| Field                                           | Description                                                                                 |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `emissions_per_creative_request_per_geo_gco2pm` | Adjusted, allocated emissions per creative request by continent (NAMER, LATAM, EMEA, JAPAC) |
-| `emissions_per_bid_request_per_geo_gco2pm`      | Adjusted, allocated emissions per bid request by continent (NAMER, LATAM, EMEA, JAPAC)      |
-| `emissions_per_rtdp_request_per_geo_gco2pm`     | Adjusted, allocated emissions per rtdp request by continent (NAMER, LATAM, EMEA, JAPAC)     |
-| `bidders`                                       | Array of ad platforms that are sent bid requests                                            |
-| `real_time_data_providers`                      | Array of ad platforms that are sent real-time data requests (not propagated)                |
-| `distribution_rate_by_bidder_by_country`        | Traffic shaping data for each bidder by country (eg `'xandr.com', 'US', 0.58`)              |
-| `average_bid_request_size`                      | Average size of a client-side bid request                                                   |
-| `sends_client_side_requests`                    | Does this platform send client-side bid requests (eg prebid client)                         |
+| Field                                                 | Description                                                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `emissions_per_creative_request_per_geo_gco2_per_imp` | Adjusted, allocated emissions per creative request by continent (NAMER, LATAM, EMEA, JAPAC) |
+| `emissions_per_bid_request_per_geo_gco2_per_imp`      | Adjusted, allocated emissions per bid request by continent (NAMER, LATAM, EMEA, JAPAC)      |
+| `emissions_per_rtdp_request_per_geo_gco2_per_imp`     | Adjusted, allocated emissions per rtdp request by continent (NAMER, LATAM, EMEA, JAPAC)     |
+| `bidders`                                             | Array of ad platforms that are sent bid requests                                            |
+| `real_time_data_providers`                            | Array of ad platforms that are sent real-time data requests (not propagated)                |
+| `distribution_rate_by_bidder_by_country`              | Traffic shaping data for each bidder by country (eg `'xandr.com', 'US', 0.58`)              |
+| `average_bid_request_size`                            | Average size of a client-side bid request                                                   |
+| `sends_client_side_requests`                          | Does this platform send client-side bid requests (eg prebid client)                         |
 
 ### Placement
 
@@ -309,9 +309,9 @@ we fall back to a default channel by device.
 ### Creative Delivery - Data Transfer
 
 ```
-creative_data_transfer_emissions_gco2pm =
-      creative_data_transfer_usage_emissions_gco2pm +
-      creative_data_transfer_embodied_emissions_gco2pm
+creative_data_transfer_emissions_gco2_per_imp =
+      creative_data_transfer_usage_emissions_gco2_per_imp +
+      creative_data_transfer_embodied_emissions_gco2_per_imp
 ```
 
 For all channels other than CTV/BVOD, use the conventional model:
@@ -384,12 +384,12 @@ power_watts =
       baseload_watts +
       dynamic_watts_per_mbps x video_bitrate_kbps / 1000
 
-creative_data_transfer_usage_emissions_gco2pm =
+creative_data_transfer_usage_emissions_gco2_per_imp =
       creative_video_duration_seconds / 3600 x
       power_watts / 1000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-creative_data_transfer_embodied_emissions_gco2pm =
+creative_data_transfer_embodied_emissions_gco2_per_imp =
       creative_video_duration_seconds x
       video_bitrate_kbps / 128 x
       embodied_emissions_gco2e_per_kb
@@ -404,9 +404,9 @@ default_creative_platforms =
       []
 creative_platforms = creative_ad_platforms ?? default_creative_platforms
 
-creative_platform_emissions_gco2pm = 0
+creative_platform_emissions_gco2_per_imp = 0
 for platform in [creative_platforms, ad_format.ad_platforms]:
-      creative_platform_emissions_gco2pm += platform.emissions_per_creative_request_per_geo_gco2pm
+      creative_platform_emissions_gco2_per_imp += platform.emissions_per_creative_request_per_geo_gco2_per_imp
 ```
 
 ### Creative Delivery - Consumer Device
@@ -435,12 +435,12 @@ device_coverage_seconds =
       audio_device_coverage_seconds :
       visual_device_coverage x time_in_view
 
-creative_consumer_device_usage_emissions_gco2pm =
+creative_consumer_device_usage_emissions_gco2_per_imp =
       device_coverage_seconds / 3600 x
       default_device_watts[device_type] / 1000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-creative_consumer_device_embodied_emissions_gco2pm =
+creative_consumer_device_embodied_emissions_gco2_per_imp =
       device_coverage_seconds x
       default_device_embodied_emissions_per_second[device_type]
 ```
@@ -448,9 +448,9 @@ creative_consumer_device_embodied_emissions_gco2pm =
 ### Media Delivery - Data Transfer
 
 ```
-media_data_transfer_emissions_gco2pm =
-      media_data_transfer_usage_emissions_gco2pm +
-      media_data_transfer_embodied_emissions_gco2pm
+media_data_transfer_emissions_gco2_per_imp =
+      media_data_transfer_usage_emissions_gco2_per_imp +
+      media_data_transfer_embodied_emissions_gco2_per_imp
 ```
 
 Determing the session seconds for a single impressions
@@ -470,12 +470,12 @@ media_data_transfer_kb_per_imp =
       property.ad_funded_percentage  /
       property.average_imps_per_session
 
-media_data_transfer_usage_emissions_gco2pm =
+media_data_transfer_usage_emissions_gco2_per_imp =
       media_data_transfer_kb_per_imp x
       usage_kwh_per_gb / 1000000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-media_data_transfer_embodied_emissions_gco2pm =
+media_data_transfer_embodied_emissions_gco2_per_imp =
       media_data_transfer_kb_per_imp x
       embodied_emissions_gco2e_per_kb
 ```
@@ -489,12 +489,12 @@ power_watts =
       baseload_watts +
       dynamic_watts_per_mbps x video_bitrate_kbps / 1000
 
-media_data_transfer_usage_emissions_gco2pm =
+media_data_transfer_usage_emissions_gco2_per_imp =
       session_seconds_per_imp / 3600 x
       power_watts / 1000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-media_data_transfer_embodied_emissions_gco2pm =
+media_data_transfer_embodied_emissions_gco2_per_imp =
       session_seconds_per_imp x
       video_bitrate_kbps / 128 x
       embodied_emissions_gco2e_per_kb
@@ -503,12 +503,12 @@ media_data_transfer_embodied_emissions_gco2pm =
 ### Media Delivery - Consumer Device
 
 ```
-media_consumer_device_usage_emissions_gco2pm =
+media_consumer_device_usage_emissions_gco2_per_imp =
       session_seconds_per_imp / 3600 x
       default_device_watts[device_type] / 1000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-media_consumer_device_embodied_emissions_gco2pm =
+media_consumer_device_embodied_emissions_gco2_per_imp =
       session_seconds_per_imp x
       default_device_embodied_emissions_per_second[device_type]
 ```
@@ -516,7 +516,7 @@ media_consumer_device_embodied_emissions_gco2pm =
 ### Media Delivery - Corporate
 
 ```
-media_corporate_emissions_gco2pm =
+media_corporate_emissions_gco2_per_imp =
       property.allocated_adjusted_corporate_emissions_kg x 1000 /
       property.total_sessions /
       property.average_imps_per_session
@@ -526,21 +526,21 @@ media_corporate_emissions_gco2pm =
 
 ```
 get_platform_emissions(ad_platform):
-      direct_emissions = emissions_per_bid_request_per_geo_gco2pm
+      direct_emissions = emissions_per_bid_request_per_geo_gco2_per_imp
       rtdp_emissions = 0
       for rtdp in ad_platform.real_time_data_providers:
-            rtdp_emissions += emissions_per_rtdp_request_per_geo_gco2pm
+            rtdp_emissions += emissions_per_rtdp_request_per_geo_gco2_per_imp
       bidder_emissions = 0
       for bidder in ad_platform.bidders:
             bidder_emissions += get_platform_emissions(bidder) x
                   ad_platform.distribution_rate_by_bidder_by_country[country, bidder] ?? 1
       return direct_emissions + rtdp_emissions + bidder_emissions
 
-ad_selection_platform_emissions_gco2pm = 0
+ad_selection_platform_emissions_gco2_per_imp = 0
 data_transfer_bytes = 0
 
 for platform in placement.ad_platforms:
-  ad_selection_platform_emissions_gco2pm += get_platform_emissions(platform)
+  ad_selection_platform_emissions_gco2_per_imp += get_platform_emissions(platform)
   platform_bytes =
       platform.average_bid_request_size ??
       default_consumer_device_request_size_bytes[channel]
@@ -558,16 +558,16 @@ for platform in placement.ad_platforms:
 ### Ad Selection - Data Transfer
 
 ```
-ad_selection_data_transfer_usage_emissions_gco2pm =
+ad_selection_data_transfer_usage_emissions_gco2_per_imp =
       data_transfer_bytes / 1000 x
       usage_kwh_per_gb / 1000000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-ad_selection_data_transfer_embodied_emissions_gco2pm =
+ad_selection_data_transfer_embodied_emissions_gco2_per_imp =
       data_transfer_bytes / 1000 x
       embodied_emissions_gco2e_per_kb
 
-ad_selection_data_transfer_emissions_gco2pm =
-      ad_selection_data_transfer_usage_emissions_gco2pm +
-      ad_selection_data_transfer_embodied_emissions_gco2pm
+ad_selection_data_transfer_emissions_gco2_per_imp =
+      ad_selection_data_transfer_usage_emissions_gco2_per_imp +
+      ad_selection_data_transfer_embodied_emissions_gco2_per_imp
 ```

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -10,6 +10,9 @@ default_consumer_device_request_size_bytes:
 default_emissions_per_creative_request_gco2pm: 0.0003
 default_emissions_per_bid_request_gco2pm:      0.11442
 default_emissions_per_rtdp_request_gco2pm:     0.01
+default_emissions_per_creative_request_gco2_per_imp: 0.0003
+default_emissions_per_bid_request_gco2_per_imp:      0.11442
+default_emissions_per_rtdp_request_gco2_per_imp:     0.01
 default_emissions_generic_ad_server: 0.000016
 
 generic_creative_ad_server:
@@ -20,6 +23,19 @@ generic_creative_ad_server:
     LATAM: 0.0001
 generic_measurement_platform:
   emissions_per_creative_request_per_geo_gco2pm:
+    NAMER: 0.0001
+    EMEA: 0.0001
+    JAPAC: 0.0003
+    LATAM: 0.0001
+
+generic_creative_ad_server:
+  emissions_per_creative_request_per_geo_gco2_per_imp:
+    NAMER: 0.0001
+    EMEA: 0.0001
+    JAPAC: 0.0003
+    LATAM: 0.0001
+generic_measurement_platform:
+  emissions_per_creative_request_per_geo_gco2_per_imp:
     NAMER: 0.0001
     EMEA: 0.0001
     JAPAC: 0.0003

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -21,20 +21,17 @@ generic_creative_ad_server:
     EMEA: 0.0001
     JAPAC: 0.0003
     LATAM: 0.0001
-generic_measurement_platform:
-  emissions_per_creative_request_per_geo_gco2pm:
-    NAMER: 0.0001
-    EMEA: 0.0001
-    JAPAC: 0.0003
-    LATAM: 0.0001
-
-generic_creative_ad_server:
   emissions_per_creative_request_per_geo_gco2_per_imp:
     NAMER: 0.0001
     EMEA: 0.0001
     JAPAC: 0.0003
     LATAM: 0.0001
 generic_measurement_platform:
+  emissions_per_creative_request_per_geo_gco2pm:
+    NAMER: 0.0001
+    EMEA: 0.0001
+    JAPAC: 0.0003
+    LATAM: 0.0001
   emissions_per_creative_request_per_geo_gco2_per_imp:
     NAMER: 0.0001
     EMEA: 0.0001

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -10,10 +10,11 @@ default_consumer_device_request_size_bytes:
 default_emissions_per_creative_request_gco2pm: 0.0003
 default_emissions_per_bid_request_gco2pm:      0.11442
 default_emissions_per_rtdp_request_gco2pm:     0.01
+default_emissions_generic_ad_server: 0.000016
 default_emissions_per_creative_request_gco2_per_imp: 0.0003
 default_emissions_per_bid_request_gco2_per_imp:      0.11442
 default_emissions_per_rtdp_request_gco2_per_imp:     0.01
-default_emissions_generic_ad_server: 0.000016
+default_emissions_generic_ad_server_gco2_per_imp: 0.000016
 
 generic_creative_ad_server:
   emissions_per_creative_request_per_geo_gco2pm:

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -60,11 +60,12 @@ default_average_seconds_per_session_excluding_ads_by_channel:
   app:      137.8
   web:      353
 default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
-  social:   40.94603782
-  ctv-bvod: 8000
-  audio:    160
-  app:      40.09649492
-  web:      1.1
+  social:   9745
+  ctv-bvod: 20640
+  streaming-video: 20640
+  audio:    240
+  app:      5525
+  web:      388
 default_average_data_kb_per_session_excluding_ads_by_channel:
   social:   9745
   ctv-bvod: 20640

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -45,13 +45,13 @@ default_property_average_imps_per_session_by_channel:
   app:      18.8
   web:      35.3
 default_property_ad_funded_percentage_by_channel:
-  dooh:     1
-  social:   1
-  ctv-bvod: 1
-  streaming-video: 1
-  audio:    1
-  app:      1
-  web:      1
+  dooh:     100
+  social:   100
+  ctv-bvod: 100
+  streaming-video: 100
+  audio:    100
+  app:      100
+  web:      100
 default_average_seconds_per_session_excluding_ads_by_channel:
   social:   238
   ctv-bvod: 2580

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -60,12 +60,18 @@ default_average_seconds_per_session_excluding_ads_by_channel:
   app:      137.8
   web:      353
 default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
+  social:   40.94603782
+  ctv-bvod: 8000
+  audio:    160
+  app:      40.09649492
+  web:      388
+default_average_data_kb_per_session_excluding_ads_by_channel:
   social:   9745
   ctv-bvod: 20640
   streaming-video: 20640
   audio:    240
   app:      5525
-  web:      388
+  web:      1.1
 default_property_g_per_imp_by_channel:
   dooh:     0.049
   social:   0.049

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -64,14 +64,14 @@ default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
   ctv-bvod: 8000
   audio:    160
   app:      40.09649492
-  web:      388
+  web:      1.1
 default_average_data_kb_per_session_excluding_ads_by_channel:
   social:   9745
   ctv-bvod: 20640
   streaming-video: 20640
   audio:    240
   app:      5525
-  web:      1.1
+  web:      388
 default_property_g_per_imp_by_channel:
   dooh:     0.049
   social:   0.049

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 36)
+        self.assertEqual(len(docs_defs), 37)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 32)
+        self.assertEqual(len(docs_defs), 36)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
Modified the defaults to have the right units and changed the inconsistent name of the bytes per session default. Left the old names in place for transition, will remove them once the api has been deployed to use the new ones. Changed the values in the bytes per session second to be consistent.