### PR TITLE
fix: align defaults with original quality imps per second and content bytes per imp

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -22,27 +22,27 @@ defaults:
     mobile: 1.200000000
   default_channel_by_device:
     pc:
-      - ctv-bvod
-      - social
-      - audio
-      - web
+    - ctv-bvod
+    - social
+    - audio
+    - web
     phone:
-      - social
-      - ctv-bvod
-      - audio
-      - app
-      - web
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
     smart-speaker:
-      - audio
+    - audio
     tablet:
-      - social
-      - ctv-bvod
-      - audio
-      - app
-      - web
+    - social
+    - ctv-bvod
+    - audio
+    - app
+    - web
     tv:
-      - ctv-bvod
-      - app
+    - ctv-bvod
+    - app
   default_consumer_device_request_size_bytes:
     app: 1000
     audio: 1000
@@ -94,14 +94,10 @@ defaults:
   default_dynamic_watts_per_mbps:
     fixed: 0.030000000
     mobile: 1.530000000
-  default_emissions_generic_ad_server: 0.000016000
   default_emissions_generic_ad_server_gco2_per_imp: 0.000016000
   default_emissions_per_bid_request_gco2_per_imp: 0.114420000
-  default_emissions_per_bid_request_gco2pm: 0.114420000
   default_emissions_per_creative_request_gco2_per_imp: 0.000300000
-  default_emissions_per_creative_request_gco2pm: 0.000300000
   default_emissions_per_rtdp_request_gco2_per_imp: 0.010000000
-  default_emissions_per_rtdp_request_gco2pm: 0.010000000
   default_image_compression_ratio: 10
   default_network_embodied_emissions_gco2e_per_kb:
     scope3:
@@ -291,18 +287,8 @@ defaults:
       JAPAC: 0.000300000
       LATAM: 0.000100000
       NAMER: 0.000100000
-    emissions_per_creative_request_per_geo_gco2pm:
-      EMEA: 0.000100000
-      JAPAC: 0.000300000
-      LATAM: 0.000100000
-      NAMER: 0.000100000
   generic_measurement_platform:
     emissions_per_creative_request_per_geo_gco2_per_imp:
-      EMEA: 0.000100000
-      JAPAC: 0.000300000
-      LATAM: 0.000100000
-      NAMER: 0.000100000
-    emissions_per_creative_request_per_geo_gco2pm:
       EMEA: 0.000100000
       JAPAC: 0.000300000
       LATAM: 0.000100000

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -6,27 +6,17 @@ defaults:
     smart-speaker: 160
     tablet: 160
     tv: 160
-  default_average_data_kb_per_session_excluding_ads_by_channel:
-    app: 5525
-    audio: 240
-    ctv-bvod: 20640
-    social: 9745
-    streaming-video: 20640
-    web: 388
   default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
-    app: 5525
-    audio: 240
-    ctv-bvod: 20640
-    social: 9745
-    streaming-video: 20640
-    web: 388
+    app: 29.500000000
+    social: 255.600000000
+    web: 1.011000000
   default_average_seconds_per_session_excluding_ads_by_channel:
-    app: 137.800000000
+    app: 140
     audio: 1500
     ctv-bvod: 2580
-    social: 238
+    social: 240
     streaming-video: 2580
-    web: 353
+    web: 320
   default_baseload_watts:
     fixed: 9.550000000
     mobile: 1.200000000
@@ -260,12 +250,12 @@ defaults:
     streaming-video: 100
     web: 100
   default_property_average_imps_per_session_by_channel:
-    app: 18.800000000
+    app: 14
     audio: 4.800000000
     ctv-bvod: 8.256000000
-    social: 19.500000000
+    social: 24
     streaming-video: 8.256000000
-    web: 35.300000000
+    web: 32
   default_property_g_per_imp_by_channel:
     app: 0.049000000
     audio: 0.049000000

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -7,32 +7,18 @@ default_consumer_device_request_size_bytes:
   audio:    1000
   social:   1000
 
-default_emissions_per_creative_request_gco2pm: 0.0003
-default_emissions_per_bid_request_gco2pm:      0.11442
-default_emissions_per_rtdp_request_gco2pm:     0.01
-default_emissions_generic_ad_server: 0.000016
 default_emissions_per_creative_request_gco2_per_imp: 0.0003
 default_emissions_per_bid_request_gco2_per_imp:      0.11442
 default_emissions_per_rtdp_request_gco2_per_imp:     0.01
 default_emissions_generic_ad_server_gco2_per_imp: 0.000016
 
 generic_creative_ad_server:
-  emissions_per_creative_request_per_geo_gco2pm:
-    NAMER: 0.0001
-    EMEA: 0.0001
-    JAPAC: 0.0003
-    LATAM: 0.0001
   emissions_per_creative_request_per_geo_gco2_per_imp:
     NAMER: 0.0001
     EMEA: 0.0001
     JAPAC: 0.0003
     LATAM: 0.0001
 generic_measurement_platform:
-  emissions_per_creative_request_per_geo_gco2pm:
-    NAMER: 0.0001
-    EMEA: 0.0001
-    JAPAC: 0.0003
-    LATAM: 0.0001
   emissions_per_creative_request_per_geo_gco2_per_imp:
     NAMER: 0.0001
     EMEA: 0.0001

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -38,12 +38,12 @@ default_platform_ad_format_by_channel:
   app:      Interstitial - 1080x1920 Banner
   web:      Leaderboard - 728x90 Banner
 default_property_average_imps_per_session_by_channel:
-  social:   19.5
+  social:   24
   ctv-bvod: 8.256
   streaming-video: 8.256
   audio:    4.8
-  app:      18.8
-  web:      35.3
+  app:      14
+  web:      32
 default_property_ad_funded_percentage_by_channel:
   dooh:     100
   social:   100
@@ -53,26 +53,16 @@ default_property_ad_funded_percentage_by_channel:
   app:      100
   web:      100
 default_average_seconds_per_session_excluding_ads_by_channel:
-  social:   238
+  social:   240
   ctv-bvod: 2580
   streaming-video: 2580
   audio:    1500
-  app:      137.8
-  web:      353
+  app:      140
+  web:      320
 default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
-  social:   9745
-  ctv-bvod: 20640
-  streaming-video: 20640
-  audio:    240
-  app:      5525
-  web:      388
-default_average_data_kb_per_session_excluding_ads_by_channel:
-  social:   9745
-  ctv-bvod: 20640
-  streaming-video: 20640
-  audio:    240
-  app:      5525
-  web:      388
+  social:   255.6
+  app:      29.5
+  web:      1.011
 default_property_g_per_imp_by_channel:
   dooh:     0.049
   social:   0.049

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 37)
+        self.assertEqual(len(docs_defs), 32)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
For audio + CTV we use the bit rate by device, so no need to have the bytes per session as a default.

For the default bytes per sessions, focusing on the default bytes per session _second_. Also, updating these values to be in line with that current defaults used in the scope3 model.

Also, finishing the renaming of fields to be clear when a value is per imp vs per 1000 imp. 