### PR TITLE
Add in default ad format identifier by channel

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -238,6 +238,14 @@ defaults:
     social: Sponsored Post - 1080x1920 Image
     streaming-video: 15s Video
     web: Leaderboard - 728x90 Banner
+  default_platform_ad_format_identifier_by_channel:
+    app: interstitial-app-phone
+    audio: 30s-audio-digital-audio-phone
+    ctv-bvod: 15s-video-ctv-bvod-tv
+    dooh: landscape-dooh
+    social: 1080-1920-sponsored-post-social-phone
+    streaming-video: 15s-video-streaming-video-tv
+    web: leaderboard-web-pc
   default_property_ad_funded_percentage_by_channel:
     app: 100
     audio: 100

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -29,6 +29,14 @@ default_device_by_channel:
   audio:    phone
   app:      phone
   web:      pc
+default_platform_ad_format_identifier_by_channel:
+  dooh:            landscape-dooh
+  social:          1080-1920-sponsored-post-social-phone
+  ctv-bvod:        15s-video-ctv-bvod-tv
+  streaming-video: 15s-video-streaming-video-tv
+  audio:           30s-audio-digital-audio-phone
+  app:             interstitial-app-phone
+  web:             leaderboard-web-pc
 default_platform_ad_format_by_channel:
   dooh:     Landscape - 1920x1080 Image
   social:   Sponsored Post - 1080x1920 Image

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 32)
+        self.assertEqual(len(docs_defs), 33)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
Expose the default ad format based on unique identifier. 