### PR TITLE
fix: include all channels in default mappings

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -42,6 +42,8 @@ defaults:
     - web
     tv:
     - ctv-bvod
+    - social
+    - audio
     - app
   default_consumer_device_request_size_bytes:
     app: 1000

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -19,6 +19,8 @@ default_channel_by_device:
     - web
   tv:
     - ctv-bvod
+    - social
+    - audio
     - app
   smart-speaker:
     - audio


### PR DESCRIPTION
Make sure to have an exhaustive list of the channels in the default channel by device mapping. Importantly, make sure TV device supports social and audio channels (which are present in most TV app stores).