### PR TITLE
add server-to-server emissions

### DIFF
--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -541,40 +541,71 @@ get_platform_emissions(ad_platform):
                   ad_platform.distribution_rate_by_bidder_by_country[country, bidder] ?? 1
       return direct_emissions + rtdp_emissions + bidder_emissions
 
-ad_selection_platform_emissions_gco2_per_imp = 0
-data_transfer_bytes = 0
-
-for platform in placement.ad_platforms:
-  ad_selection_platform_emissions_gco2_per_imp += get_platform_emissions(platform)
-  platform_bytes =
-      platform.average_bid_request_size ??
-      default_consumer_device_request_size_bytes[channel]
-  data_transfer_bytes += default_consumer_device_request_size_bytes[channel]
-  if platform.sends_client_side_requests:
+get_platform_client_side_data_transfer(platform, is_client_side):
+    if !is_client_side
+        return 0
+    bytes_sent = 0   
     for bidder in platform.bidders:
       bidder_bytes =
           bidder.average_bid_request_size ??
           default_consumer_device_request_size_bytes[channel]
-      data_transfer_bytes +=
+      bytes_sent +=
           bidder_bytes x
           platform.distribution_rate_by_bidder_by_country[country, bidder] ?? 1
+    return bytes_sent
+
+get_platform_server_side_data_transfer(platform, is_client_side):
+    bytes_sent = 0   
+    for bidder in platform.bidders:
+        bytes_sent += get_platform_server_side_data_transfer(bidder, false)
+        if is_client_side:
+          continue
+        bidder_bytes =
+            bidder.average_bid_request_size ??
+            default_server_side_request_size_bytes
+        bytes_sent +=
+            bidder_bytes x
+            platform.distribution_rate_by_bidder_by_country[country, bidder] ?? 1
+    return bytes_sent
+
+ad_selection_platform_emissions_gco2_per_imp = 0
+client_side_data_transfer_bytes = 0
+server_side_data_transfer_bytes = 0
+
+for platform in placement.ad_platforms:
+  ad_selection_platform_emissions_gco2_per_imp += get_platform_emissions(platform)
+  client_side_data_transfer_bytes +=
+      platform.average_bid_request_size ??
+      default_consumer_device_request_size_bytes[channel]
+  client_side_data_transfer_bytes += default_consumer_device_request_size_bytes[channel]
+  client_side_data_transfer_bytes +=
+      get_platform_client_side_data_transfer(platform, platform.sends_client_side_requests)
+  server_side_data_transfer_bytes += 
+      get_platform_server_side_data_transfer(platform, platform.sends_client_side_requests)
+  
 ```
 
 ### Ad Selection - Data Transfer
 
 ```
-ad_selection_data_transfer_usage_emissions_gco2_per_imp =
-      data_transfer_bytes / 1000 x
+ad_selection_client_side_data_transfer_usage_emissions_gco2_per_imp =
+      client_side_data_transfer_bytes / 1000 x
       usage_kwh_per_gb / 1000000 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
-ad_selection_data_transfer_embodied_emissions_gco2_per_imp =
-      data_transfer_bytes / 1000 x
+ad_selection_client_side_data_transfer_embodied_emissions_gco2_per_imp =
+      client_side_data_transfer_bytes / 1000 x
       embodied_emissions_gco2e_per_kb
 
+ad_selection_server_side_data_transfer_emissions_gco2_per_imp =
+      server_side_data_transfer_bytes / 1000 x
+      default_server_to_server_kwh_per_gb / 1000000 x
+      lookup_carbon_intensity_gco2e_by_continent(country, region, utc_datetime)
+
 ad_selection_data_transfer_emissions_gco2_per_imp =
-      ad_selection_data_transfer_usage_emissions_gco2_per_imp +
-      ad_selection_data_transfer_embodied_emissions_gco2_per_imp
+      ad_selection_server_side_data_transfer_emissions_gco2_per_imp +
+      ad_selection_client_side_data_transfer_usage_emissions_gco2_per_imp +
+      ad_selection_client_side_data_transfer_embodied_emissions_gco2_per_imp
 ```
 
 ### Model Quality

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -589,21 +589,26 @@ for platform in placement.ad_platforms:
 
 ```
 ad_selection_client_side_data_transfer_usage_emissions_gco2_per_imp =
-      client_side_data_transfer_bytes / 1000 x
-      usage_kwh_per_gb / 1000000 x
+      client_side_data_transfer_bytes / 1024 x
+      usage_kwh_per_gb / 1024 / 1024 x
       lookup_carbon_intensity_gco2e_per_kwh(country, region, utc_datetime)
 
 ad_selection_client_side_data_transfer_embodied_emissions_gco2_per_imp =
-      client_side_data_transfer_bytes / 1000 x
+      client_side_data_transfer_bytes / 1024 x
       embodied_emissions_gco2e_per_kb
 
-ad_selection_server_side_data_transfer_emissions_gco2_per_imp =
-      server_side_data_transfer_bytes / 1000 x
-      default_server_to_server_kwh_per_gb / 1000000 x
+ad_selection_server_side_data_transfer_usage_emissions_gco2_per_imp =
+      server_side_data_transfer_bytes / 1024 x
+      default_server_to_server_kwh_per_gb / 1024 / 1024 x
       lookup_carbon_intensity_gco2e_by_continent(country, region, utc_datetime)
 
+ad_selection_server_side_data_transfer_embodied_emissions_gco2_per_imp =
+      server_side_data_transfer_bytes / 1024 x
+      default_server_to_server_embodied_emissions_gco2e_per_kb
+
 ad_selection_data_transfer_emissions_gco2_per_imp =
-      ad_selection_server_side_data_transfer_emissions_gco2_per_imp +
+      ad_selection_server_side_data_transfer_usage_emissions_gco2_per_imp +
+      ad_selection_server_side_data_transfer_embodied_emissions_gco2_per_imp +
       ad_selection_client_side_data_transfer_usage_emissions_gco2_per_imp +
       ad_selection_client_side_data_transfer_embodied_emissions_gco2_per_imp
 ```

--- a/docs/data_transfer.mdx
+++ b/docs/data_transfer.mdx
@@ -81,7 +81,6 @@ The [SRI methodology](https://www.sri-france.org/wp-content/uploads/2023/06/SRI_
 The SRI methodology suggests a ratio of 90% fixed to 10% mobile. However, this ratio is not representative globally. The ITU publishes [research](https://datahub.itu.int) on fixed and mobile traffic by country. This indicates that for 2022 the weighted average of global traffic was 23.6% mobile. However, this research notably omits the US which is likely similar to other advanced economies in the 5% range, so we have added this to the dataset as an estimate (along with the 10% France number for SRI consistency).
 
 ## Server-to-server data transfer
+[Marion Ficher, Françoise Berthoud, Anne-Laure Ligozat, Patrick Sigonneau, Maxime Wisslé, et al.. Assessing the carbon footprint of the data transmission on a backbone network. 24th Conference on Innovation in Clouds, Internet and Networks, Mar 2021, Paris, France. hal-03196527](https://hal.science/hal-03196527)
 
-From [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/docs/methodology#chosen-coefficient)
-
-"It is safe to assume hyper-scale cloud providers have a very energy efficient network between their data centers with their own optical fiber networks and submarine cable [source]. Data exchanges between data-centers are also done with a very high bitrate (~100 GbE -> 100 Gbps), thus being the most efficient use-case. Given these assumptions, we have decided to use the smallest coefficient available to date: 0.001 kWh/Gb. Again, we welcome feedback or contributions to improve this coefficient."
+Per Table III, a local request (which is the likely case for RTB where the round trip time needs to be ~10ms or less), and assuming a peak day as the majority of requests will be at peak, use phase emissions are 0.433 gCO2e/GB and embodied emissions are .0143 gCO2e/GB. To reverse the use phase to kWh we remove the emissions factor used (0.108 kgCO2e/kWh) and get 0.00401 kWh/GB.

--- a/docs/data_transfer.mdx
+++ b/docs/data_transfer.mdx
@@ -79,3 +79,9 @@ The [SRI methodology](https://www.sri-france.org/wp-content/uploads/2023/06/SRI_
 
 ## Handling unknown networks
 The SRI methodology suggests a ratio of 90% fixed to 10% mobile. However, this ratio is not representative globally. The ITU publishes [research](https://datahub.itu.int) on fixed and mobile traffic by country. This indicates that for 2022 the weighted average of global traffic was 23.6% mobile. However, this research notably omits the US which is likely similar to other advanced economies in the 5% range, so we have added this to the dataset as an estimate (along with the 10% France number for SRI consistency).
+
+## Server-to-server data transfer
+
+From [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/docs/methodology#chosen-coefficient)
+
+"It is safe to assume hyper-scale cloud providers have a very energy efficient network between their data centers with their own optical fiber networks and submarine cable [source]. Data exchanges between data-centers are also done with a very high bitrate (~100 GbE -> 100 Gbps), thus being the most efficient use-case. Given these assumptions, we have decided to use the smallest coefficient available to date: 0.001 kWh/Gb. Again, we welcome feedback or contributions to improve this coefficient."

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -1,5 +1,5 @@
 ```
-default_consumer_device_request_size_bytes:
+default_client_side_device_request_size_bytes:
   web:             1500
   app:             1000
   ctv-bvod:        0
@@ -7,6 +7,8 @@ default_consumer_device_request_size_bytes:
   audio:           1000
   social:          1000
   streaming-video: 0
+
+default_server_side_request_size_bytes: 1500
 
 default_emissions_per_creative_request_gco2_per_imp: 0.0003
 default_emissions_per_bid_request_gco2_per_imp:      0.11442

--- a/docs/snippets/defaults_conventional_model.mdx
+++ b/docs/snippets/defaults_conventional_model.mdx
@@ -13,4 +13,5 @@ default_network_embodied_emissions_gco2e_per_kb:
   sri:
     fixed:  0.00000443
     mobile: 0.00000797
+default_server_to_server_kwh_per_gb: 0.001
 ```

--- a/docs/snippets/defaults_conventional_model.mdx
+++ b/docs/snippets/defaults_conventional_model.mdx
@@ -13,5 +13,6 @@ default_network_embodied_emissions_gco2e_per_kb:
   sri:
     fixed:  0.00000443
     mobile: 0.00000797
-default_server_to_server_kwh_per_gb: 0.001
+default_server_to_server_kwh_per_gb: 0.00401
+default_server_to_server_embodied_emissions_gco2e_per_kb: 0.000000136
 ```


### PR DESCRIPTION
Add server-to-server emissions. Open question: what do we use for the emissions factor since the datacenter may not be in the same country as the consumer. Should we try to model at the continent level? Presumably nobody puts datacenter in the most polluting spot if they can help it (ie Poland), but also not reasonable to assume they're all in France.

Source for S2S emissions: https://hal.science/hal-03196527

@github-benjamin-davy 