### PR TITLE
fix: Social defaults

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -8,7 +8,7 @@ defaults:
     tv: 160
   default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
     app: 29.500000000
-    social: 255.600000000
+    social: 38
     web: 1.011000000
   default_average_seconds_per_session_excluding_ads_by_channel:
     app: 140
@@ -266,7 +266,7 @@ defaults:
     audio: 0.049000000
     ctv-bvod: 0.049000000
     dooh: 0.049000000
-    social: 0.049000000
+    social: 0.150000000
     streaming-video: 0.049000000
     web: 0.049000000
   default_time_in_view_seconds: 6

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -73,7 +73,7 @@ default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
   web:      1.011
 default_property_g_per_imp_by_channel:
   dooh:     0.049
-  social:   0.20
+  social:   0.15
   streaming-video: 0.049
   ctv-bvod: 0.049
   audio:    0.049

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -68,12 +68,12 @@ default_average_seconds_per_session_excluding_ads_by_channel:
   app:      140
   web:      320
 default_average_data_kb_per_session_seconds_excluding_ads_by_channel:
-  social:   255.6
+  social:   38
   app:      29.5
   web:      1.011
 default_property_g_per_imp_by_channel:
   dooh:     0.049
-  social:   0.049
+  social:   0.20
   streaming-video: 0.049
   ctv-bvod: 0.049
   audio:    0.049


### PR DESCRIPTION
Revising the social defaults to be in line with the model updates to the core platforms.

- default data transfer kb comes down to more in line in app (slightly higher, but not as high as before)
- default media distribution corporate emissions goes up. we need to come back to review the the default corporate emissions of the other channels
