### PR TITLE
adserver defaults by channel

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -98,6 +98,8 @@ defaults:
     fixed: 0.030000000
     mobile: 1.530000000
   default_emissions_generic_ad_server_gco2_per_imp: 0.000016000
+  default_emissions_generic_ad_server_gco2_per_imp_by_channel:
+    social: 0.004300000
   default_emissions_per_bid_request_gco2_per_imp: 0.114420000
   default_emissions_per_creative_request_gco2_per_imp: 0.000300000
   default_emissions_per_rtdp_request_gco2_per_imp: 0.010000000

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -12,6 +12,8 @@ default_emissions_per_creative_request_gco2_per_imp: 0.0003
 default_emissions_per_bid_request_gco2_per_imp:      0.11442
 default_emissions_per_rtdp_request_gco2_per_imp:     0.01
 default_emissions_generic_ad_server_gco2_per_imp: 0.000016
+default_emissions_generic_ad_server_gco2_per_imp_by_channel:
+  social: 0.0043
 
 generic_creative_ad_server:
   emissions_per_creative_request_per_geo_gco2_per_imp:

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -239,7 +239,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 33)
+        self.assertEqual(len(docs_defs), 34)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""


### PR DESCRIPTION
Adding ad server defaults by channel rather than having a single adserver default that is used for all channels.

Starting with a specific social adserver default as we now have better numbers on the emissions associated with social adserving.