### PR TITLE
Minor updates for OLV support

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -23,12 +23,14 @@ defaults:
   default_channel_by_device:
     pc:
     - ctv-bvod
+    - streaming-video
     - social
     - audio
     - web
     phone:
     - social
     - ctv-bvod
+    - streaming-video
     - audio
     - app
     - web
@@ -37,11 +39,13 @@ defaults:
     tablet:
     - social
     - ctv-bvod
+    - streaming-video
     - audio
     - app
     - web
     tv:
     - ctv-bvod
+    - streaming-video
     - social
     - audio
     - app
@@ -51,7 +55,7 @@ defaults:
     ctv-bvod: 0
     dooh: 0
     social: 1000
-    streaming-video: 0
+    streaming-video: 1000
     web: 1500
   default_device_by_channel:
     app: phone

--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -23,32 +23,32 @@ defaults:
   default_channel_by_device:
     pc:
     - ctv-bvod
-    - streaming-video
     - social
     - audio
     - web
+    - streaming-video
     phone:
     - social
     - ctv-bvod
-    - streaming-video
     - audio
     - app
     - web
+    - streaming-video
     smart-speaker:
     - audio
     tablet:
     - social
     - ctv-bvod
-    - streaming-video
     - audio
     - app
     - web
+    - streaming-video
     tv:
     - ctv-bvod
-    - streaming-video
     - social
     - audio
     - app
+    - streaming-video
   default_consumer_device_request_size_bytes:
     app: 1000
     audio: 1000

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -15,14 +15,15 @@ import ChannelMappingDefaults from "/snippets/defaults_channel_mapping.mdx";
 
 ### Channels
 
-| Channel    | Description                                    |
-| ---------- | ---------------------------------------------- |
-| `web`      | Website that is not primarily social or CTV    |
-| `app`      | Mobile app that is not primarily social or CTV |
-| `social`   | A social platform (Snapchat, Facebook, etc)    |
-| `ctv-bvod` | A TV-like streaming platform                   |
-| `audio`    | Audio content (podcasts, streaming music)      |
-| `dooh`     | Digital out of home - billboards, transit, etc |
+| Channel           | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `web`             | Website that is not primarily social or CTV    |
+| `app`             | Mobile app that is not primarily social or CTV |
+| `social`          | A social platform (Snapchat, Facebook, etc)    |
+| `ctv-bvod`        | A TV-like streaming platform                   |
+| `streaming-video` | Website or app with online video content       |
+| `audio`           | Audio content (podcasts, streaming music)      |
+| `dooh`            | Digital out of home - billboards, transit, etc |
 
 ### Device Types
 

--- a/docs/snippets/defaults_ad_platform.mdx
+++ b/docs/snippets/defaults_ad_platform.mdx
@@ -6,7 +6,7 @@ default_consumer_device_request_size_bytes:
   dooh:            0
   audio:           1000
   social:          1000
-  streaming-video: 0
+  streaming-video: 1000
 
 default_emissions_per_creative_request_gco2_per_imp: 0.0003
 default_emissions_per_bid_request_gco2_per_imp:      0.11442

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -3,29 +3,29 @@ default_channel_by_device:
   phone:
     - social
     - ctv-bvod
-    - streaming-video
     - audio
     - app
     - web
+    - streaming-video
   tablet:
     - social
     - ctv-bvod
-    - streaming-video
     - audio
     - app
     - web
+    - streaming-video
   pc:
     - ctv-bvod
-    - streaming-video
     - social
     - audio
     - web
+    - streaming-video
   tv:
     - ctv-bvod
-    - streaming-video
     - social
     - audio
     - app
+    - streaming-video
   smart-speaker:
     - audio
 default_device_by_channel:

--- a/docs/snippets/defaults_channel_mapping.mdx
+++ b/docs/snippets/defaults_channel_mapping.mdx
@@ -3,22 +3,26 @@ default_channel_by_device:
   phone:
     - social
     - ctv-bvod
+    - streaming-video
     - audio
     - app
     - web
   tablet:
     - social
     - ctv-bvod
+    - streaming-video
     - audio
     - app
     - web
   pc:
     - ctv-bvod
+    - streaming-video
     - social
     - audio
     - web
   tv:
     - ctv-bvod
+    - streaming-video
     - social
     - audio
     - app


### PR DESCRIPTION
1- Added "streaming-video" (OLV) in channel definition.
2- Added default_consumer_device_request_size_bytes for "streaming-video" (OLV).
3- Ensured channel identification can default to "streaming-video" (OLV).