### PR TITLE
Minor ai meth docs updates

### DIFF
--- a/docs/inference.mdx
+++ b/docs/inference.mdx
@@ -59,12 +59,6 @@ predicted_request_duration = avg(duration)
 predicted_inferences = (average output tokens + 1)
 ```
 
-Next, calculate the baseline power use of the cluster and spread it across requests by duration:
-
-```
-baseline_energy_per_request_second = E(0,0) / sum(duration)
-```
-
 Calculate the marginal energy per inference:
 ```
 marginal_gpu_per_inference = sum(gpu_pct)/sum(inferences)
@@ -77,9 +71,9 @@ marginal_energy_per_inference = marginal_gpu_per_inference x marginal_energy_per
                                 marginal_cpu_per_inference x marginal_energy_per_cpu_pct
 ```
 
-Calculate the energy use for a request:
+Calculate the energy use for a request, taking into account the idle cluster power:
 ```
-usage_energy_per_request = baseline_energy_per_request_second x predicted_request_duration +
+usage_energy_per_request = idle_cluster_power x predicted_request_duration +
                      marginal_energy_per_inference x predicted_inferences
 ```
 

--- a/docs/inference.mdx
+++ b/docs/inference.mdx
@@ -88,14 +88,10 @@ usage_energy_per_request = baseline_energy_per_request_second x predicted_reques
 Calculate embodied emissions and water usage using predicted request duration:
 ```
 embodied_emissions_per_second = EmbEm(1) / 3600
-embodied_emissions_per_request_second = embodied_emissions_per_second / sum(duration)
-
-embodied_emissions_per_request = predicted_request_duration x embodied_emissions_per_request_second
+embodied_emissions_per_request = predicted_request_duration x embodied_emissions_per_second
 
 embodied_h2o_per_second = EmbH2O(1) / 3600
-embodied_h2o_per_request_second = embodied_h2o_per_second / sum(duration)
-
-embodied_h2o_per_request = predicted_request_duration x embodied_emissions_per_request_second
+embodied_h2o_per_request = predicted_request_duration x embodied_h2o_per_second
 ```
 
 Calculate the training and fine-tuning emissions using:

--- a/docs/training.mdx
+++ b/docs/training.mdx
@@ -77,7 +77,7 @@ When disclosed data is not present or not complete, we need to use predictive or
 The BLOOM paper includes most of the required parameters for carbon emissions. However, it does not include data for water consumption. We use the fallbacks for the missing data points in the calculations below.
 
 Some assumptions:
-- The 35.8 tons of CO2 for the intermediate models implies proportional reservation and usage as the final model (2.45x)
+- The 35.8 tons of CO2 for the intermediate models implies proportional reservation and usage as the final model. The total emissions for all models is then 35.8+24.69 tons, so we can extrapolate by a factor of 2.45x.
 
 Normalized training data
 

--- a/docs/training.mdx
+++ b/docs/training.mdx
@@ -77,15 +77,15 @@ When disclosed data is not present or not complete, we need to use predictive or
 The BLOOM paper includes most of the required parameters for carbon emissions. However, it does not include data for water consumption. We use the fallbacks for the missing data points in the calculations below.
 
 Some assumptions:
-- The 35.8 tons of CO2 for the intermediate models implies proportional reservation and usage as the final model (1.45x)
+- The 35.8 tons of CO2 for the intermediate models implies proportional reservation and usage as the final model (2.45x)
 
 Normalized training data
 
 | Component | Disclosed data |
 | --------- | -------------- |
-| Total reserved time | 289 days (118 x 1.45) |
+| Total reserved time | 289 days (118 x 2.45) |
 | Reservation start time | August 2021 (finish date of June 2022 minus 289 days) |
-| GPU hours for final model | 2,653,326 (1,082,990 x 1.45) |
+| GPU hours for final model | 2,653,326 (1,082,990 x 2.45) |
 
 ## Calculation of carbon emissions
 

--- a/docs/training.mdx
+++ b/docs/training.mdx
@@ -205,7 +205,7 @@ TC means the total training cost
 | ------------------------------------ | ----------- | ----------------- | --------------- | --- | ------- |
 | Remaining use life                   | N           | N - 1             | N - 2           |     | 0       |
 | Training cost remaining (TCR)        | TC          | TC - TC / N       | TC - 2 x TC / N |     | 0       |
-| Projected inferences remaining (PCR) | PI          | PI x (N - 1)      | PI X (N - 2)    |     | 0       |
+| Projected inferences remaining (PCR) | PI          | PI x (N - 1) / N  | PI X (N - 2) / N|     | 0       |
 | Training cost per inference (TPI)    | TCR1 / PCR1 | TCR2 / PCR2       | TCR3 / PCR3     |     | 0       |
 | Training cost "billed" (TCB)         | TC/N x TPI  | TCB1 + TC/N x TPI |                 |     | TC      |
 
@@ -215,7 +215,7 @@ Amortization schedule after month 1
 | ------------------------------------ | ----------- | ---------------- | ----------------- | --- | ------- |
 | Remaining use life                   | N           | N - 1            | N - 2             |     | 0       |
 | Training cost remaining (TCR)        | TC          | TC - TCB1        | TC - TCB2         |     | 0       |
-| Projected inferences remaining (PCR) | PI          | AI1 x (N - 1)    | AI1 x (N - 2)     |     | 0       |
+| Projected inferences remaining (PCR) | PI          | AI1 x (N - 1) / N| AI1 x (N - 2) / N |     | 0       |
 | Training cost per inference (TPI)    | TCR1 / PCR1 | TCR2 / PCR2      | TCR3 / PCR3       |     | TC / PI |
 | Actual inferences                    | AI1         |                  |                   |     |         |
 | Training cost "billed" (TCB)         | AI1 x TPI   | TCB1 + AI2 x TPI |                   |     | TC      |


### PR DESCRIPTION
Some minor improvements to the AI preview methodology docs.

* Fixed the multiplier on the Training page from 1.45 to 2.45 and added a tiny bit more explanation
* Added in divide-by-N for the PCR calculation in the amortization table in the Training page
* Removed the unnecessary division by sum(duration) for embodied emissions on the Inference Service page
* Used idle_power_gpu directly instead of E(0,0) / sum(duration) on the Inference Service page, which should be more clear