### PR TITLE
docs: add pages title metadata

### DIFF
--- a/docs/ad_tech_model.mdx
+++ b/docs/ad_tech_model.mdx
@@ -1,3 +1,7 @@
+---
+title: "Ad tech model"
+---
+
 # Methodology to Measure Emissions from Ad Tech Platforms
 
 The ad tech platform (ATP) model is built around the idea that ATPs integrate with other ATPs as part of a directed graph starting from the publisher. For instance, making a bid request to an SSP will generate many more bid requests to DSPs and possibly to real-time data providers as well.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1,3 +1,7 @@
+---
+title: "API"
+---
+
 # API
 
 API code is located `./scope3_methodology/api/api.py` and dockerfile is `./Dockerfile`

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -1,3 +1,7 @@
+---
+title: "Calculations"
+---
+
 import ConventionalModelDefaults from "/snippets/defaults_conventional_model.mdx";
 import PowerModelDefaults from "/snippets/defaults_power_model.mdx";
 import VideoPlayerDefaults from "/snippets/defaults_video_player.mdx";

--- a/docs/consumer_devices.mdx
+++ b/docs/consumer_devices.mdx
@@ -1,3 +1,7 @@
+---
+title: "Consumer devices"
+---
+
 # Measuring Emissions for Consumer Devices
 
 ## Overview of Emissions by Device
@@ -27,10 +31,10 @@ The following sections outline the sources and assumptions used to calculate the
 From [Negaoctet](Negaoctet):
 
 | Device  | Lifetime impact excluding use (kgCO2e) | Description                                                                                                                                                 |
-| ------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Desktop | 277                        | Desktop; personal use; average configuration: 1 CPU, 10 GB RAM, 1173 GB HDD, 442 GB SSD, mix of integrated or separated graphic card, 6 years lifespan; RAS |
-| Laptop  | 175                        | Laptop; use mix, personal use; average configuration: 14,6 inches screen, 1 CPU, 11 GB RAM, 497 GB SSD, 5 years lifespan; RAS                               |
-| Monitor | 69                         | Computer monitors; use mix, personal and professional use; average dimension (24 inches) and technology (98.6% LCD, 1.4% OLED), 6,6 years lifespan; RAS     |
+| ------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Desktop | 277                                    | Desktop; personal use; average configuration: 1 CPU, 10 GB RAM, 1173 GB HDD, 442 GB SSD, mix of integrated or separated graphic card, 6 years lifespan; RAS |
+| Laptop  | 175                                    | Laptop; use mix, personal use; average configuration: 14,6 inches screen, 1 CPU, 11 GB RAM, 497 GB SSD, 5 years lifespan; RAS                               |
+| Monitor | 69                                     | Computer monitors; use mix, personal and professional use; average dimension (24 inches) and technology (98.6% LCD, 1.4% OLED), 6,6 years lifespan; RAS     |
 
 From [Urban et al](#urban-et-al-2019):
 

--- a/docs/corporate_model.mdx
+++ b/docs/corporate_model.mdx
@@ -1,3 +1,7 @@
+---
+title: "Corporate model"
+---
+
 # Estimating corporate emissions
 
 Imagine a company that has done a perfect job of measuring its carbon emissions. This company would have analyzed every expense in its financials, gone a level deeper to get activity data, performed lifecycle analysis on each of its products, and then asked each company in its supply chain to do the same.

--- a/docs/creative.mdx
+++ b/docs/creative.mdx
@@ -1,3 +1,7 @@
+---
+title: "Creative"
+---
+
 # Measuring the carbon footprint of creatives and ad formats
 
 ## Terminology: Placements, Ad Formats, Creatives, and Assets

--- a/docs/data_quality.mdx
+++ b/docs/data_quality.mdx
@@ -1,3 +1,7 @@
+---
+title: "Data quality"
+---
+
 Given the many layers of assumptions and allocations involved in modeling the emissions of the complex advertising supply chain, it is critical to understand the accuracy of emissions data both for assessing provider quality and as a gating factor to incorporate data into corporate and regulatory reporting.
 
 ## Data Quality Components
@@ -12,6 +16,7 @@ Each data element included in an emissions model should include:
 - Ad format data quality (1-5)
 
 In addition, it's important that the provided activity data has sufficient granularity for accurate modeling:
+
 - Input granularity score (1-5)
 
 ## Grid mix
@@ -19,12 +24,12 @@ In addition, it's important that the provided activity data has sufficient granu
 Grid intensity can fluctuate significantly on an hourly basis due to the variable nature of both renewable energy sources (sun, wind) and electricity demand. To achieve effective decarbonization, having hourly data is critical. However, this isn't broadly available in many countries.
 
 | Data source and timescale  | Data Quality |
-| -------------------------- | ------------- |
-| Worldwide                  | 1             |
-| Country, monthly or annual | 2             |
-| Country, daily             | 3             |
-| Country + region, daily    | 4             |
-| Country + region, hourly   | 5             |
+| -------------------------- | ------------ |
+| Worldwide                  | 1            |
+| Country, monthly or annual | 2            |
+| Country, daily             | 3            |
+| Country + region, daily    | 4            |
+| Country + region, hourly   | 5            |
 
 ## Organization
 
@@ -37,11 +42,11 @@ Criteria for accurate sustainability data at the organization level:
 - A sustainability report should be published within 6 months of the end of the previous calendar year to be considered for sustainability purposes.
 
 | Report element                  | Data Quality |
-| ------------------------------- | ------------- |
-| Scope 1 and 2, market-based     | +1            |
-| Location-based scope 2          | +1            |
-| All scope 3 categories provided | +1            |
-| Lines of business broken out    | +1            |
+| ------------------------------- | ------------ |
+| Scope 1 and 2, market-based     | +1           |
+| Location-based scope 2          | +1           |
+| All scope 3 categories provided | +1           |
+| Lines of business broken out    | +1           |
 
 ## Ad tech platforms
 
@@ -60,19 +65,19 @@ The quality score for each group starts at 1 and increments based on the presenc
 | Above data broken down by at least 1 additional dimension (placement, country, channel, seller ID) | +1           |
 | Data is shared monthly                                                                             | +1           |
 
-| Request Quality Score                                | Data Quality |
-| ---------------------------------------------------- | ------------ |
-| Server Emissions                                     | +1           |
-| Total Bid Requests                                   | +1           |
-| Above data broken down by server location            | +1           |
-| Organization data quality ≥ 3                        | +1           |
+| Request Quality Score                     | Data Quality |
+| ----------------------------------------- | ------------ |
+| Server Emissions                          | +1           |
+| Total Bid Requests                        | +1           |
+| Above data broken down by server location | +1           |
+| Organization data quality ≥ 3             | +1           |
 
-| Traffic Shaping Quality Score                                                                 | Data Quality |
-| --------------------------------------------------------------------------------------------- | ------------ |
-| Ratio of ad requests processed vs bid requests sent for each integrated demand partner        | +1           |
-| Above data broken out by inventory ID                                                         | +1           |
-| Above data broken out by country                                                              | +1           |
-| Data is shared monthly                                                                        | +1           |
+| Traffic Shaping Quality Score                                                          | Data Quality |
+| -------------------------------------------------------------------------------------- | ------------ |
+| Ratio of ad requests processed vs bid requests sent for each integrated demand partner | +1           |
+| Above data broken out by inventory ID                                                  | +1           |
+| Above data broken out by country                                                       | +1           |
+| Data is shared monthly                                                                 | +1           |
 
 For DSPs, real time data providers might be used instead of “demand partners” under Traffic Shaping Quality Score.
 
@@ -84,12 +89,12 @@ For web, app, social, CTV and digital audio media properties, the three key metr
 These metrics can be extrapolated from other publicly shared metrics (such as Monthly Active Users, Revenue, etc.), or estimated by 3rd party tools that employ panels (such as SimilarWeb). They can also be observed through crawling and scraping, or measured directly by the publisher through tools like Google Analytics.
 
 | Property Metrics                | Example Data Source             | Data Quality |
-| ------------------------------- | ------------------------------- | ------------- |
-| Not available                   | N/a                             | 1             |
-| Extrapolated from other metrics | Yearly Financial Report         | 2             |
-| 3rd party estimated             | Panels                          | 3             |
-| Observed                        | Controlled Crawling or Scraping | 4             |
-| 1st party measured              | Publisher Analytics             | 5             |
+| ------------------------------- | ------------------------------- | ------------ |
+| Not available                   | N/a                             | 1            |
+| Extrapolated from other metrics | Yearly Financial Report         | 2            |
+| 3rd party estimated             | Panels                          | 3            |
+| Observed                        | Controlled Crawling or Scraping | 4            |
+| 1st party measured              | Publisher Analytics             | 5            |
 
 Each key metric’ data quality is evaluated separately, then the property’ data quality score is the lower closest integer (floor) of the sum of each key metric’ data quality score divided by 3.
 
@@ -108,34 +113,34 @@ For DOOH screens, the key metric is power draw.
 It can be acquired on a per screen basis, for example using a power metre, or can be estimated using using screen size or manufacturer specifications.
 
 | Property Metrics                                         | Granularity       | Data Quality |
-| -------------------------------------------------------- | ----------------- | ------------- |
-| Not available                                            | N/a               | 1             |
-| Extrapolated based on physical dimensions and venue type | N/a               | 2             |
-| Derived from manufacturer’ specifications (typical draw) | N/a               | 3             |
-| Observed from energy bills or measured through metres    | Monthly or Yearly | 4             |
-| Observed from energy bills or measured through metres    | Hourly            | 5             |
+| -------------------------------------------------------- | ----------------- | ------------ |
+| Not available                                            | N/a               | 1            |
+| Extrapolated based on physical dimensions and venue type | N/a               | 2            |
+| Derived from manufacturer’ specifications (typical draw) | N/a               | 3            |
+| Observed from energy bills or measured through metres    | Monthly or Yearly | 4            |
+| Observed from energy bills or measured through metres    | Hourly            | 5            |
 
 ## Ad Stack
 
 The accuracy of the ad stack used by the publisher for the placement depends on accurate representation of all direct and indirect ad platforms. The ad stack score starts at 1 and increments based on provided data components.
 
 | Ad Stack Component                                | Data Quality |
-| ------------------------------------------------- | ------------- |
-| Ad stack mapped via observed data                 | +1            |
-| Ads.txt validated                                 | +1            |
-| Ad platforms mapped to region, device, and format | +1            |
-| Placements mapped to GPID and ad platform         | +1            |
+| ------------------------------------------------- | ------------ |
+| Ad stack mapped via observed data                 | +1           |
+| Ads.txt validated                                 | +1           |
+| Ad platforms mapped to region, device, and format | +1           |
+| Placements mapped to GPID and ad platform         | +1           |
 
 ## Ad Format
 
 The ad format data should include all of elements included upon the initial render of the ad format. Advertiser-provided assets should be identified so that they can be replaced with actual data during the measurement process. All ad platforms that are part of the rendering process should be included, especially ad servers, real-time measurement providers, and video players.
 
-| Ad Format data element                                         | Data Quality |
-| -------------------------------------------------------------- | ------------- |
-| Technical specs provided                                       | +1            |
-| Media assets identified                                        | +1            |
-| All static assets measured and included                        | +1            |
-| Video player is identified and has data quality of at least 3 | +1            |
+| Ad Format data element                                        | Data Quality |
+| ------------------------------------------------------------- | ------------ |
+| Technical specs provided                                      | +1           |
+| Media assets identified                                       | +1           |
+| All static assets measured and included                       | +1           |
+| Video player is identified and has data quality of at least 3 | +1           |
 
 ## Input granularity
 
@@ -162,12 +167,12 @@ Granularity % is the percentage of recommended input fields that are provided an
 ### Input granularity to data quality map
 
 | Granularity % | Data Quality |
-| ------------- | ------------- |
-| < 30%         | 1             |
-| 30% - 50%     | 2             |
-| 50% - 70%     | 3             |
-| 70% - 90%     | 4             |
-| 90% - 100%    | 5             |
+| ------------- | ------------ |
+| < 30%         | 1            |
+| 30% - 50%     | 2            |
+| 50% - 70%     | 3            |
+| 70% - 90%     | 4            |
+| 90% - 100%    | 5            |
 
 ### Input granularity example
 

--- a/docs/data_transfer.mdx
+++ b/docs/data_transfer.mdx
@@ -1,3 +1,7 @@
+---
+title: "Data transfer"
+---
+
 # Emissions from Data Transfer
 
 ![Global ICT footprint vs bandwidth](images/malmodin-sweden-2018.png)
@@ -21,8 +25,8 @@ These bottom-up numbers indicate that the majority of emissions from broadband u
 - As a starting point in understanding all the various approaches for understanding the carbon footprint of various networks, we recommend [this article by Gauthier Roussilhe](https://gauthierroussilhe.com/articles/explications-sur-l-empreinte-carbone-du-streaming-et-du-transfert-de-donnees).
 - [Base Station Energy Use in Dense Urban and Suburban Areas](https://ieeexplore.ieee.org/document/10005276?source=authoralert) includes a table of the base station (RAT) energy use for 3G, 4G, and 5G with 2.8, 0.104, and 0.0104 kWh/GB respectively
 - [Power consumption evaluation of mobile radio access networks using a bottom-up approach](https://hera.futuregenerations.be/sites/www.futuregenerations.be/files/summary_masterthesis4g5g_louisgolard.pdf) proposes 10 kbit/J for 4G base stations, equivalent to 0.23 kWh/GB. It suggests 5G is 3-4x more efficient, approximately 0.06 kWh/GB.
- - For mobile vs fixed data the [2020 EU ICT impact study](https://circabc.europa.eu/sd/a/8b7319ba-ce4f-49ea-a6e6-b28df00b20d1/ICT%20impact%20study%20final.pdf) suggests 0.03 kWh/GB for fixed, 0.14 kWh/GB for mobile.
- - The 0.03 kWh/GB number aligns with what is in the graphic above (0.03 W/Mbps) at relatively low bandwidth. [Aslan et al](https://onlinelibrary.wiley.com/doi/10.1111/jiec.12630) suggest that fixed-line networks should be 0.06 kWh/GB in 2020 and halving every two years. This is consistent with the 0.03 kWh/GB figure.
+- For mobile vs fixed data the [2020 EU ICT impact study](https://circabc.europa.eu/sd/a/8b7319ba-ce4f-49ea-a6e6-b28df00b20d1/ICT%20impact%20study%20final.pdf) suggests 0.03 kWh/GB for fixed, 0.14 kWh/GB for mobile.
+- The 0.03 kWh/GB number aligns with what is in the graphic above (0.03 W/Mbps) at relatively low bandwidth. [Aslan et al](https://onlinelibrary.wiley.com/doi/10.1111/jiec.12630) suggest that fixed-line networks should be 0.06 kWh/GB in 2020 and halving every two years. This is consistent with the 0.03 kWh/GB figure.
 - Per DIMPACT methodology, "Range 0.1 – 1.0 kWh/GB (2020). After review of the available data the Carbon Trust used a value of 0.1 kWh/GB based on [Pihkoka et al](https://www.mdpi.com/2071-1050/10/7/2494) in their Whitepaper ‘Carbon impact of video streaming’ (2021)"
 - Greenspector has a highly detailed analysis of the impact of data transfer [here](https://greenspector.com/en/what-impact-does-the-network-have-on-digital-services/).
 - Malmodin J, Lundén D. [The Energy and Carbon Footprint of the Global ICT and E&M Sectors 2010–2015](https://doi.org/10.3390/su10093027). Sustainability. 2018; 10(9):3027.
@@ -30,6 +34,7 @@ These bottom-up numbers indicate that the majority of emissions from broadband u
 ## Power usage by bandwidth (Conventional Model)
 
 The ideal data source would factor in:
+
 - Relative use of fixed connections, 3G, 4G, and 5G on a per-country basis
 - The exponential growth of data use, ideally split between streaming and non-streaming use cases
 
@@ -78,4 +83,5 @@ Mobile Network Energy (Amn) = 1.2W + 1.53W/Mbps
 The [SRI methodology](https://www.sri-france.org/wp-content/uploads/2023/06/SRI_Calculating-the-carbon-footprint_V2.pdf) includes embodied emissions data from ADEME/Negaoctet, which seem reasonable.
 
 ## Handling unknown networks
+
 The SRI methodology suggests a ratio of 90% fixed to 10% mobile. However, this ratio is not representative globally. The ITU publishes [research](https://datahub.itu.int) on fixed and mobile traffic by country. This indicates that for 2022 the weighted average of global traffic was 23.6% mobile. However, this research notably omits the US which is likely similar to other advanced economies in the 5% range, so we have added this to the dataset as an estimate (along with the 10% France number for SRI consistency).

--- a/docs/digital_out_of_home.mdx
+++ b/docs/digital_out_of_home.mdx
@@ -1,3 +1,7 @@
+---
+title: "Digital out-of-home"
+---
+
 # Digital out-of-home (DOOH)
 
 ## Boundaries of measurement

--- a/docs/lifecycle.mdx
+++ b/docs/lifecycle.mdx
@@ -1,3 +1,7 @@
+---
+title: "Lifecycle"
+---
+
 # Life Cycle Analysis for Advertising
 
 Life cycle assessment or LCA (also known as life cycle analysis) is a methodology for assessing environmental impacts associated with all the stages of the life cycle of a commercial product, process, or service. For instance, in the case of a manufactured product, environmental impacts are assessed from raw material extraction and processing (cradle), through the product's manufacture, distribution and use, to the recycling or final disposal of the materials composing it (grave). (from ["Life-Cycle Assessment"](https://en.wikipedia.org/wiki/Life-cycle_assessment) - Wikipedia).

--- a/docs/property_metrics.mdx
+++ b/docs/property_metrics.mdx
@@ -1,3 +1,7 @@
+---
+title: "Property metrics"
+---
+
 # Calculating property metrics
 
 The property represents the media upon which advertising is delivered. This could be a website, an app, a screen, a stream, or any other surface where advertising is delivered.
@@ -20,11 +24,11 @@ To calculate the average data transfer of a user session:
 
 1. Create a table of page views for the top URLs on the site, and using an ad blocker, calculate the data transfer to load these URLs
 
-| URL           | Page Views | Data Transfer (KB) |
-| ------------- | ---------- | ------------------ |
-| /index        | 1000       | 778.2              |
-| /sports       | 300        | 489.1              |
-| /news/today   | 500        | 1832.9             |
+| URL         | Page Views | Data Transfer (KB) |
+| ----------- | ---------- | ------------------ |
+| /index      | 1000       | 778.2              |
+| /sports     | 300        | 489.1              |
+| /news/today | 500        | 1832.9             |
 
 2. Calculate the weighted average data transfer per page view
 

--- a/docs/publisher_model.mdx
+++ b/docs/publisher_model.mdx
@@ -1,3 +1,7 @@
+---
+title: "Publisher model"
+---
+
 # Publisher Model
 
 Publishers (media owners, platforms, etc) tend to be complex businesses, often with thousands of employees and complex organizational structures. Publishers often own and operate properties in different countries, sometimes with joint ventures, and have multiple revenue streams.


### PR DESCRIPTION
The [https://methodology.scope3.com/llms.txt](https://methodology.scope3.com/llms.txt) is `null` for all titles. I couldn't test locally, but my guess is because the metadata is missing. This PR will add the metadata titles for each page