### PR TITLE
Update Linear TV label in the channels' table

### DIFF
--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -30,7 +30,7 @@ import BroadcastingDefaults from "/snippets/defaults_broadcasting.mdx";
 | `audio`           | Audio content (podcasts, streaming music)      |
 | `dooh`            | Digital out of home - billboards, transit, etc |
 | `search`          | A Search engine (Google, Bing, etc)            |
-| `dooh`            | Scheduled broadcast or cable television        |
+| `linear-tv`       | Scheduled broadcast or cable television        |
 
 ### Device Types
 


### PR DESCRIPTION
The previous channels' table listed the dooh channel twice with the second occurrence corresponding to the Linear TV definition.