### PR TITLE
chore: Update methodology for Linear TV and Classic OOH (GMSF v1.3)

### DIFF
--- a/defaults/docs-defaults.yaml
+++ b/defaults/docs-defaults.yaml
@@ -112,6 +112,8 @@ defaults:
   default_count_ad_platform:
     dooh: 6
     search: 1
+  default_datacenter_compute_embodied_emissions_kgCO2e_per_second: 0.000007130
+  default_datacenter_compute_use_phase_kwh_per_second: 0.000164000
   default_device_by_channel:
     app: phone
     ctv-bvod: tv
@@ -184,14 +186,35 @@ defaults:
   default_emissions_per_bid_request_gco2_per_imp: 0.114420000
   default_emissions_per_creative_request_gco2_per_imp: 0.000300000
   default_emissions_per_rtdp_request_gco2_per_imp: 0.010000000
+  default_eol_kgco2e_emissions_per_kg_by_material:
+    backlit_paper: 0.158940000
+    recycled_paper: 0.158940000
   default_expected_lifetime_years: 10.000000000
   default_freight_transport_emissions_kgco2e_tonne_transported_per_km: 0.110000000
+  default_freight_transport_kgco2e_emissions_per_tonne_km:
+    classic-ooh: 0.792000000
+  default_illumination_power_draw_watts_per_sq_metre: 21.400000000
   default_illumination_power_draw_watts_per_sq_metre_per_hour: 100.000000000
   default_image_compression_ratio: 10
   default_impressions_per_creative: 1000000
+  default_installation_transport_kgco2e_emissions_per_vehicle_km:
+    classic-ooh: 0.256000000
   default_iptv_network_distribution:
     fixed: 0.999000000
     mobile: 0.001000000
+  default_manufacturing_kgco2e_emissions_per_kg_by_material:
+    backlit_paper: 0.257000000
+    recycled_paper: 0.257000000
+  default_material_by_ooh_ad_format:
+    2 Sheet Poster: recycled_paper
+    6 Sheet: recycled_paper
+    96 Sheet: backlit_paper
+    Small A1: recycled_paper
+  default_material_mass_kg_per_sq_metre_by_ooh_ad_format:
+    2 Sheet Poster: 0.150000000
+    6 Sheet: 0.150000000
+    96 Sheet: 0.170000000
+    Small A1: 0.150000000
   default_mechanical_rotation_power_draw_watts_per_sq_metre_per_hour: 12.500000000
   default_network_embodied_emissions_gco2e_per_kb:
     scope3:
@@ -490,6 +513,8 @@ defaults:
     leaflet: 2.000000000
     magazine: 1.500000000
     newspaper: 1.000000000
+  default_printing_to_storage_distance_km:
+    classic-ooh: 200
   default_printing_to_storage_distance_km_per_ad:
     classic-ooh:
       AD: 0.500000000
@@ -609,6 +634,19 @@ defaults:
       YE: 0.500000000
       ZA: 0.500000000
       ZW: 0.500000000
+  default_production_loss_ratio_by_channel:
+    app: 1
+    classic-ooh: 1.110000000
+    ctv-bvod: 1
+    digital-audio: 1
+    dooh: 1
+    linear-tv: 1
+    print: 1.110000000
+    search: 1
+    social: 1
+    streaming-video: 1
+    traditional-radio: 1
+    web: 1
   default_property_ad_funded_percentage_by_channel:
     app: 100
     ctv-bvod: 100
@@ -787,6 +825,8 @@ defaults:
       YE: 4.000000000
       ZA: 4.000000000
       ZW: 4.000000000
+  default_storage_to_site_distance_km_per_ad:
+    classic-ooh: 0.700000000
   default_storage_usage_pct:
     cloud_storage: 45
     hard_disk_drive: 25
@@ -797,7 +837,11 @@ defaults:
   default_structure_pct_recycling:
     classic-ooh: 58.750000000
   default_structure_recycling_emissions_kgco2e_per_sq_metre: 0.000000000
+  default_substrate_production_kgco2e_emissions_per_kg_by_material:
+    backlit_paper: 0.920000000
+    recycled_paper: 1.050000000
   default_time_in_view_seconds: 3
+  default_transcoding_outputs_number: 6
   default_tv_home_equipment_embodied_gco2e_per_second_by_tv_distribution_method:
     cable: 0.005346759
     iptv: 0.005492307
@@ -808,12 +852,13 @@ defaults:
     iptv: 21
     ota: 1
     satellite: 22
-  default_tv_signal_preparation_power_watt: 16700
-  default_tv_signal_transmission_embodied_gco2e_per_second: 27
+  default_tv_signal_preparation_embodied_gco2e_per_second: 0.007130000
+  default_tv_signal_preparation_power_watt: 590.400000000
+  default_tv_signal_transmission_embodied_gco2e_per_second: 30.630000000
   default_tv_signal_transmission_power_by_tv_distribution_method_watt:
-    cable: 16000
-    ota: 165000
-    satellite: 3150
+    cable: 469793
+    ota: 469793
+    satellite: 550001
   default_usage_kwh_per_gb:
     scope3:
       fixed: 0.016500000
@@ -835,6 +880,7 @@ defaults:
     streaming-video: impression
     web: impression
   default_video_player_size_bytes: 350000
+  default_video_transcoding_time_seconds: 30
   edge_node_embodied_gco2e_per_kb: 0.000000588
   edge_node_use_watts_per_kb: 0.000000430
   generic_creative_ad_server:

--- a/docs/calculations.mdx
+++ b/docs/calculations.mdx
@@ -15,6 +15,7 @@ import ChannelMappingDefaults from "/snippets/defaults_channel_mapping.mdx";
 import BroadcastingDefaults from "/snippets/defaults_broadcasting.mdx";
 import CreativeStorageDefaults from "/snippets/defaults_creative_storage.mdx";
 import AssetDefaults from "/snippets/defaults_asset_size.mdx";
+import PhysicalAdProductionDefaults from "/snippets/defaults_physical_production.mdx";
 import ClassicOOHDefaults from "/snippets/defaults_classic_ooh.mdx";
 import PrintDefaults from "/snippets/defaults_print.mdx";
 import DOOHDefaults from "/snippets/defaults_dooh.mdx";
@@ -179,7 +180,7 @@ Native product carousel
 
 ### Conventional model data transfer by network type
 
-The Scope3 values below are from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf).
+The Scope3 values below are from [GMSF](https://adnetzero.com/global-media-sustainability-framework/).
 SRI values from [SRIxAD database 2.1](https://github.com/SRISyndicatRegiesInternet/SRIxAD-DigitalCampaignsCarbonFramework/releases/download/v2.1.0/Referentiel.SRI.x.AD.-.V2.1_partage.zip), original source ADEME_220830_v1.4 (now considered outdated).
 
 <ConventionalModelDefaults />
@@ -198,7 +199,7 @@ From [ITU Data Hub](https://datahub.itu.int/) (2024 data), these ratios do not a
 
 ### Video player characteristics
 
-Default video player size from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf)
+Default video player size from [GMSF](https://adnetzero.com/global-media-sustainability-framework/)
 
 <VideoPlayerDefaults />
 
@@ -224,19 +225,19 @@ See [Consumer Devices](./consumer_devices)
 
 ### Time in view for non-video ads
 
-Default in view time from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf)
+Default in view time from [GMSF](https://adnetzero.com/global-media-sustainability-framework/)
 
 <TimeInViewDefaults />
 
 ### Ad platform defaults
 
-Observations from various channels and CDN / Edge Node emission factors from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf)
+Observations from various channels and CDN / Edge Node emission factors from [GMSF](https://adnetzero.com/global-media-sustainability-framework/)
 
 <AdPlatformDefaults />
 
 ### Channel and device type mappings
 
-The default ad formats for the Web and App channels are based on the [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf) defaults for creative payload.
+The default ad formats for the Web and App channels are based on the [GMSF](https://adnetzero.com/global-media-sustainability-framework/) defaults for creative payload.
 
 <ChannelMappingDefaults />
 
@@ -246,13 +247,17 @@ The default ad formats for the Web and App channels are based on the [GMSF 1.2](
 
 ### Creative storage defaults
 
-Emission factors from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf), along with assumptions on average distribution per storage type, default multipliers to estimate the required storage space based on the delivered creative size and default impressions per creative.
+Emission factors from [GMSF](https://adnetzero.com/global-media-sustainability-framework/), along with assumptions on average distribution per storage type, default multipliers to estimate the required storage space based on the delivered creative size and default impressions per creative.
 
 <CreativeStorageDefaults />
 
 ### Asset size defaults
 
 <AssetDefaults />
+
+### Physical Ad Production defaults
+
+<PhysicalAdProductionDefaults />
 
 ### Classic OOH defaults
 

--- a/docs/channel_considerations.mdx
+++ b/docs/channel_considerations.mdx
@@ -26,9 +26,9 @@ We classify Linear TV as content that is transmitted via traditional broadcast m
 | Broadcast method                                          | Equipment involved                                                                                          |
 | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Over-the-air (OTA) & Digital Terrestrial Television (DTT) | Transmitting towers, repeaters, household antennas…                                                         |
-| Cable                                                     | Same as the Internet network (infrastructure is typically shared across telephone, television and Internet) |
+| Cable                                                     | Managed cable television distribution infrastructure (shared physical network). |
 | Satellite                                                 | Transmitting Satellite dishes, Satellite, Receiving satellite dishes, set top boxes                         |
-| IPTV (Internet Protocol Television)                       | Internet network, set top boxes                                                                             |
+| IPTV (Internet Protocol Television)                       | IP-based managed multicast television delivery over telecom infrastructure.                                                                             |
 
 ## Boundaries of Measurement
 
@@ -39,7 +39,7 @@ The Scope3 Linear TV model focuses on estimating emissions coming from the distr
 | Media Production                 | Content production                                     | Not Included |                                                                                                                                                                       |
 | Creative Production              | Ad production                                          | Not included |                                                                                                                                                                       |
 | Media Distribution               | Corporate emissions from TV network                    | Included     |                                                                                                                                                                       |
-| Media & Creative Distribution    | Broadcast Signal preparation, transmission & reception | Included     | Encoding & multiplexing<br/>OTA/DTT, cable, Satellite & IPTV networks (use phase & embodied)<br/>Household Equipment used for signal reception (use phase & embodied) |
+| Media & Creative Distribution    | Broadcast Signal preparation, transmission & reception | Included     | Signal preparation, multiplexing, transmission infrastructure, and household signal reception equipment. Per GMSF v1.3 guidance, creative transcoding is modelled separately under Tech Manipulation for unicast/multicast delivery (e.g. IPTV), while equivalent broadcast-side transformation activities remain included in distribution. |
 | Media & Creative Consumer Device | TV viewing                                             | Included     | Television device (use phase & embodied)                                                                                                                              |
 
 ## Emissions Calculation Methodology
@@ -98,6 +98,8 @@ The prevalence of each TV broadcast method varies by TV network and geographical
 
 ### Household Equipment Emissions
 
+Scope3 retains household signal reception equipment emissions in Linear TV, even though GMSF v1.3 excludes these infrastructure components.
+
 #### Energy Consumption
 
 We consider some household equipment "passive", meaning that they do not require any power to receive the broadcast signal, and others "active".
@@ -137,7 +139,7 @@ Similarly to how we model consumer devices (see [Consumer Devices](./consumer_de
 
 ### TV Viewing Emissions
 
-We follow the same methodology as described in [Consumer Devices](./consumer_devices), accounting for both use phase (energy consumption) and embodied emission (production & disposal), aligned with GMSF 1.2:
+We follow the same methodology as described in [Consumer Devices](./consumer_devices), accounting for both use phase (energy consumption) and embodied emission (production & disposal), aligned with GMSF:
 
 | Device                | Power (W) | PEPS (gCO2e/s) |
 | --------------------- | --------- | -------------- |

--- a/docs/consumer_devices.mdx
+++ b/docs/consumer_devices.mdx
@@ -48,7 +48,7 @@ Since we do not know the exact device a consumer is using (most reporting is agg
 
 ![Visual representation of the PC emissions model](images/pc_emissions_model.png)
 
-We use the following defaults from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf): a use-phase energy intensity of 0.0000154 kWh per second (55.44 W power draw) and embodied emissions of 0.00000545 kgCO2e per second. The listed data sources are ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)) and Scope3.
+We use the following defaults from [GMSF](https://adnetzero.com/global-media-sustainability-framework/): a use-phase energy intensity of 0.0000154 kWh per second (55.44 W power draw) and embodied emissions of 0.00000545 kgCO2e per second. The listed data sources are ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)) and Scope3.
 
 ## Tablet
 
@@ -58,7 +58,7 @@ We don't have a stat on daily usage of tablets. Assuming that people use them in
 
 For energy use, [iBatteryLife](https://ibatterylife.com/ipad-battery-life-test/) compares multiple iPad models and battery life is around 10 hours for each. The average iPad, per [Sir Apfelot](https://sir-apfelot.de/en/battery-capacity-ipad-mah-19060/), has around 30 Wh of battery capacity. Thus, a tablet has an average power draw of 3W.
 
-We use the following defaults from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf): a use-phase energy intensity of 0.0000014 kWh per second (5.04 W power draw) and embodied emissions of 0.0000257 kgCO2e per second. The embodied emission factor is much higher than for the other devices due to considering low daily usage. The listed data source is ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)).
+We use the following defaults from [GMSF](https://adnetzero.com/global-media-sustainability-framework/): a use-phase energy intensity of 0.0000014 kWh per second (5.04 W power draw) and embodied emissions of 0.0000257 kgCO2e per second. The embodied emission factor is much higher than for the other devices due to considering low daily usage. The listed data source is ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)).
 
 ## Smartphone
 
@@ -68,7 +68,7 @@ The typical person uses her phone for 4 hours and 23 minutes a day per [Statista
 
 As an example, per [GSM Arena](#gsmarena), the Apple iPhone 13 takes 16 hours and 8 minutes to run out of battery when browsing the internet (similar to video playback). In idle mode, it takes 174 hours to discharge. It has 12.41Wh of battery capacity per [Macworld](#macworld). Thus, the iphone consumes 0.77W when active, and 0.071W when idle.
 
-We use the following defaults from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf): a use-phase energy intensity of 0.0000013 kWh per second (4.68 W power draw) and embodied emissions of 0.00000655 kgCO2e per second. The use-phase value is considered conservative and based on video playback. The listed data source is ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)).
+We use the following defaults from [GMSF](https://adnetzero.com/global-media-sustainability-framework/): a use-phase energy intensity of 0.0000013 kWh per second (4.68 W power draw) and embodied emissions of 0.00000655 kgCO2e per second. The use-phase value is considered conservative and based on video playback. The listed data source is ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)).
 
 ## Television
 
@@ -93,7 +93,7 @@ Based on 3.9 hours/day of usage, the embodied emissions from a TV and set top bo
 
 A detailed study of many TV models can be found at [ecocostsavings.com](https://ecocostsavings.com/tv-wattage/), indicating that the average power draw of a TV in the US is 59W active, 0.5W standby. This data is not tied to a scientific study but does indicate that overall power usage may have declined since the Urban study above.
 
-We use the following defaults from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf): a use-phase energy intensity of 0.000038 kWh per second (136.8 W power draw) and embodied emissions of 0.00000865 kgCO2e per second. The listed data source is ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)).
+We use the following defaults from [GMSF](https://adnetzero.com/global-media-sustainability-framework/): a use-phase energy intensity of 0.000038 kWh per second (136.8 W power draw) and embodied emissions of 0.00000865 kgCO2e per second. The listed data source is ADEME ([Base Empreinte, "Numérique 2.0" dataset, 2025](https://base-empreinte.ademe.fr/)).
 
 ## Smart Speaker
 

--- a/docs/creative.mdx
+++ b/docs/creative.mdx
@@ -28,7 +28,7 @@ To determine consumer device emissions we need to know whether the ad controls t
 
 - For a full screen or primary placement ad(standard TV/radio commercial, etc) the energy used by the consumer device during the display of the creative is determined by multiplying the duration of the creative by the energy use of the consumer device.
 
-- For an ad that is not full screen that is embedded in content- for instance, a banner ad on a web site, an autoplaying out-stream video, or a sponsored post in a social news feed - the energy use should be proportionate to the percentage of the consumer device used by the creative and the average time that the placement is in view. We align with GMSF 1.2 and assume a default of 3 seconds as the average time an embedded ad is in view.
+- For an ad that is not full screen that is embedded in content- for instance, a banner ad on a web site, an autoplaying out-stream video, or a sponsored post in a social news feed - the energy use should be proportionate to the percentage of the consumer device used by the creative and the average time that the placement is in view. We align with GMSF and assume a default of 3 seconds as the average time an embedded ad is in view.
 
 The time the ad is on the device multiplied by the percentage of the screen/device used by the creative is `device coverage-seconds`. The embodied emissions for the delivery of the creative are `(device coverage-seconds) x (embodied emissions per second)` and the usage emissions are `(device coverage-seconds) x (energy per second)`. See [consumer device methodology](./consumer_devices) for details on the per-device calculations.
 
@@ -41,7 +41,7 @@ Format notes:
 
 ### Tech Manipulation / Physical Production Emissions
 
-For digital channels we model the emissions related to the storage of creative materials (also called the master bundle). We use emission factors per type of storage from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf), along with assumptions to allocate these emissions per impression:
+For digital channels we model the emissions related to the storage of creative materials (also called the master bundle). We use emission factors per type of storage from [GMSF](https://adnetzero.com/global-media-sustainability-framework/), along with assumptions to allocate these emissions per impression:
 
 - the average distribution per storage type,
 - the default impressions per creative,
@@ -73,7 +73,7 @@ The total data transfer from a creative can be calculated as `static assets + vi
 
 For digital channels, we calculate Ad Platform emissions corresponding to the Ad Serving and Measurement processes. See the [defaults](./calculations#ad-platform-defaults) and associated [calculations](./calculations#creative-delivery-platform) used.
 
-By default, we apply the emission factors from [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf), which evaluate Ad Serving from a CDN/Edge Node. These emission factors are expressed per unit of data transferred from a creative.
+By default, we apply the emission factors from [GMSF](https://adnetzero.com/global-media-sustainability-framework/), which evaluate Ad Serving from a CDN/Edge Node. These emission factors are expressed per unit of data transferred from a creative.
 
 - Use-phase energy intensity of transferring 1MB from an edge node: 4.30E-07 kWh / MB
 - Embodied emissions intensity of transferring 1MB from an edge node: 5.88E-07 kgCO2e / MB

--- a/docs/data_transfer.mdx
+++ b/docs/data_transfer.mdx
@@ -35,7 +35,7 @@ These bottom-up numbers indicate that the majority of emissions from broadband u
 
 We apply the conventional model to all channels.
 
-The [GMSF 1.2](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf), the latest "official" industry source, uses ADEME emission factors based on a this [study on the environmental footprint of French ISPs](https://librairie.ademe.fr/industrie-et-production-durable/6789-evaluation-de-l-empreinte-environnementale-de-la-fourniture-d-acces-a-internet-en-france.html#product-presentation). Although based on primary and recent data (2023) the values are unfortunately not time-adjusted or adapted to different markets.
+The [GMSF](https://adnetzero.com/global-media-sustainability-framework/), the latest "official" industry source, uses ADEME emission factors based on a this [study on the environmental footprint of French ISPs](https://librairie.ademe.fr/industrie-et-production-durable/6789-evaluation-de-l-empreinte-environnementale-de-la-fourniture-d-acces-a-internet-en-france.html#product-presentation). Although based on primary and recent data (2023) the values are unfortunately not time-adjusted or adapted to different markets.
 
 The initial ADEME work considers two components to calculate network-related electricity consumption for both fixed and mobile networks:
 
@@ -58,7 +58,7 @@ The same approach is applied for embodied emissions. The resulting conventional 
 
 ## Power usage by time and bandwidth (Power Model)
 
-**Note**: We have deprecated the use of the Power Model to align with GMSF 1.2. The information below is valid only for CTV‑BVOD and OLV measurements conducted before October 2025.
+**Note**: We have deprecated the use of the Power Model to align with GMSF. The information below is valid only for CTV‑BVOD and OLV measurements conducted before October 2025.
 
 Per [Carbon Trust](https://ctprodstorageaccountp.blob.core.windows.net/prod-drupal-files/documents/resource/public/Carbon-impact-of-video-streaming.pdf):
 

--- a/docs/lifecycle.mdx
+++ b/docs/lifecycle.mdx
@@ -33,7 +33,7 @@ We have seen three well-documented methodologies for the use phase of media and 
 - [DIMPACT](https://dimpact.org/publications)
 - [SRI](https://www.sri-france.org/wp-content/uploads/2021/11/SRI_Calculating-the-carbon-footprint_VF.pdf)
 - [GroupM](https://www.wpp.com/en/-/media/project/wpp/images/sustainability/media-decarbonisation/groupm_mediadecarb_jul15.pdf)
-- [GMSF](https://adnetzero.com/wp-content/uploads/2025/06/GlobalMediaSustainabilityFrameworkV1.2.pdf)
+- [GMSF](https://adnetzero.com/global-media-sustainability-framework/)
 
 ### Life cycle boundaries by methodology
 

--- a/docs/snippets/defaults_broadcasting.mdx
+++ b/docs/snippets/defaults_broadcasting.mdx
@@ -1,4 +1,8 @@
 ```
+default_video_transcoding_time_seconds: 30
+default_transcoding_outputs_number: 6
+default_datacenter_compute_use_phase_kwh_per_second: 0.000164
+default_datacenter_compute_embodied_emissions_kgCO2e_per_second: 0.00000713
 default_percent_tv_distribution_method:
   cable: 28.6
   iptv: 25.2
@@ -30,12 +34,13 @@ default_percent_tv_distribution_method_by_country:
     iptv: 20.7
     ota: 19.3
     satellite: 16.7
-default_tv_signal_preparation_power_watt: 16700
+default_tv_signal_preparation_power_watt: 590.4
+default_tv_signal_preparation_embodied_gco2e_per_second: 0.00713
 default_tv_signal_transmission_power_by_tv_distribution_method_watt:
-  cable: 16000
-  ota: 165000
-  satellite: 3150
-default_tv_signal_transmission_embodied_gco2e_per_second: 27
+  cable: 469793
+  ota: 469793
+  satellite: 550001
+default_tv_signal_transmission_embodied_gco2e_per_second: 30.63
 default_tv_home_equipment_power_by_tv_distribution_method_watt:
   cable: 16
   iptv: 21

--- a/docs/snippets/defaults_classic_ooh.mdx
+++ b/docs/snippets/defaults_classic_ooh.mdx
@@ -1,4 +1,31 @@
 ```
+default_material_mass_kg_per_sq_metre_by_ooh_ad_format:
+  6 Sheet:        0.150
+  96 Sheet:       0.170
+  Small A1:       0.150
+  2 Sheet Poster: 0.150
+default_material_by_ooh_ad_format:
+  6 Sheet:        recycled_paper
+  96 Sheet:       backlit_paper
+  Small A1:       recycled_paper
+  2 Sheet Poster: recycled_paper
+default_eol_kgco2e_emissions_per_kg_by_material:
+  recycled_paper: 0.15894
+  backlit_paper:  0.15894
+default_substrate_production_kgco2e_emissions_per_kg_by_material:
+  recycled_paper: 1.05
+  backlit_paper:  0.92
+default_manufacturing_kgco2e_emissions_per_kg_by_material:
+  recycled_paper: 0.257
+  backlit_paper:  0.257
+default_printing_to_storage_distance_km:
+  classic-ooh: 200
+default_freight_transport_kgco2e_emissions_per_tonne_km:
+  classic-ooh: 0.792
+default_storage_to_site_distance_km_per_ad:
+  classic-ooh: 0.7
+default_installation_transport_kgco2e_emissions_per_vehicle_km:
+  classic-ooh: 0.256
 default_ad_landfill_emissions_kgco2e_per_sq_metre: 0.291
 default_ad_pct_recycling:
   classic-ooh: 20.0
@@ -9,6 +36,7 @@ default_emissions_kgco2e_per_km_travelled: 0.2543
 default_mechanical_rotation_power_draw_watts_per_sq_metre_per_hour: 12.5
 default_digital_screen_landfill_emissions_kgco2e_per_sq_metre: 20.9
 default_expected_lifetime_years: 10.0
+default_illumination_power_draw_watts_per_sq_metre: 21.4
 default_illumination_power_draw_watts_per_sq_metre_per_hour: 100.0
 default_ooh_ad_production_kgco2e_emissions_per_sq_metre: 3.78
 default_ooh_campaign_duration_days: 14

--- a/docs/snippets/defaults_physical_production.mdx
+++ b/docs/snippets/defaults_physical_production.mdx
@@ -1,0 +1,15 @@
+```
+default_production_loss_ratio_by_channel:
+  dooh: 1
+  social: 1
+  ctv-bvod: 1
+  streaming-video: 1
+  digital-audio: 1
+  app: 1
+  web: 1
+  linear-tv: 1
+  search: 1
+  traditional-radio: 1
+  classic-ooh: 1.11
+  print: 1.11
+```

--- a/scope3_methodology/test/test_api.py
+++ b/scope3_methodology/test/test_api.py
@@ -240,7 +240,7 @@ class TestAPI(unittest.TestCase):
         )
 
         docs_defs = docs_defaults
-        self.assertEqual(len(docs_defs), 112)
+        self.assertEqual(len(docs_defs), 128)
 
     def test_get_all_con_networking_connection_device_fixed_defaults(self):
         """Test get_all_networking_connection_device_defaults returns expected output"""

--- a/scope3_methodology/utils/yaml_helpers.py
+++ b/scope3_methodology/utils/yaml_helpers.py
@@ -76,10 +76,17 @@ def yaml_load(stream, **kwargs):
     return yaml.load(stream, Loader, **kwargs)  # type: ignore
 
 
+class CustomDumper(yaml.Dumper):
+    """Custom Dumper that indents list items under their parent key"""
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow=flow, indentless=False)
+
+
 def yaml_dump(obj: object):
     """Custom yaml dump to correctly write Decimal fields"""
     # Do not print tags, produces invalid yaml
     yaml.emitter.Emitter.process_tag = lambda *args: False  # type: ignore
     # Print all values without pointers and aliases
-    yaml.Dumper.ignore_aliases = lambda *args: True  # type: ignore
-    return yaml.dump(obj, default_flow_style=False, Dumper=yaml.Dumper)
+    CustomDumper.ignore_aliases = lambda *args: True  # type: ignore
+    return yaml.dump(obj, default_flow_style=False, Dumper=CustomDumper)


### PR DESCRIPTION
Re-applies the GMSF v1.3 methodology changes from PR #289, which were reverted in PR #290 due to a production incident (`Methodology defaults file version 24 is not supported`). The API has since been updated to support the new defaults count.

Reverts PR #290 (revert: revert-pr289-channel-methodology).

## Changes

- **Linear TV**: Adds transcoding/datacenter compute defaults for future API use; updates signal preparation and transmission power/embodied values to GMSF v1.3
- **Classic OOH**: Adds physical production defaults (materials, mass, substrate production, manufacturing, EOL, transport distances, illumination)
- **Physical production**: New `defaults_physical_production.mdx` with `default_production_loss_ratio_by_channel` (classic-ooh and print: 1.11, all others: 1)
- **Docs**: Updates `channel_considerations.mdx` and `calculations.mdx` for GMSF v1.3 guidance; replaces all GMSF 1.2 PDF links with canonical URL
- **Fix**: `yaml_dump` now uses `CustomDumper` to preserve correct list indentation in `docs-defaults.yaml`

Closes https://linear.app/scope3-projects/issue/SUS-97/update-methodology-repo-for-linear-tv-and-classic-ooh

## Test plan

- [ ] CI passes
- [ ] API updated to handle 128 defaults before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)